### PR TITLE
adding controllers module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(


### PR DESCRIPTION
If you don't import find_packages setuptools will not include the submodules in the egg file when you install with "install" instead ode "develop".
