### PR TITLE
Don't round in set_volume, do round in volume_up/down

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -192,14 +192,14 @@ class Chromecast(object):
         Returns the new volume.
 
         """
-        volume = self.status.volume_level
+        volume = round(self.status.volume_level, 1)
         return self.set_volume(volume + 0.1)
 
     def volume_down(self):
         """ Decrement the volume by 0.1 unless it is already 0.
         Returns the new volume.
         """
-        volume = self.status.volume_level
+        volume = round(self.status.volume_level, 1)
         return self.set_volume(volume - 0.1)
 
     def __del__(self):

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -367,7 +367,7 @@ class ReceiverController(BaseController):
         Returns the new volume.
 
         """
-        volume = min(max(0, round(volume, 1)), 1)
+        volume = min(max(0, volume), 1)
         self.send_message({MESSAGE_TYPE: 'SET_VOLUME',
                            'volume': {'level': volume}})
         return volume


### PR DESCRIPTION
`volume_up` and `volume_down` were actually broken because of all the rounding. The chromecast seems to pretty much always return an extremely precise float approximation of whatever you put in, and as such, `volume_up` and `volume_down` need to do this to get consistent volume (inc|dec)rements. Also, given this information, didn't figure there was much point in rounding in `set_volume` at all, since you can do more precise volumes if you want.
