### PR TITLE
Fixed incorrect variable name 'filter'

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -63,7 +63,7 @@ def get_chromecasts(tries=None, **filters):
 
     if 'ip' in filters:
         for chromecast in cc_list:
-            if chromecast.host != filter['ip']:
+            if chromecast.host != filters['ip']:
                 excluded_cc.add(chromecast)
         filters.pop('ip')
 


### PR DESCRIPTION
Produced error:

line 60, in get_chromecasts
   if chromecast.host != filter['ip']:
TypeError: 'type' object is not subscriptable
