### PR TITLE
Fix bugs in Chromecast.is_idle and ReceiverController.launch_app

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -316,7 +316,11 @@ class Chromecast:
         return (
             self.status is None
             or self.app_id in (None, IDLE_APP_ID)
-            or (not self.status.is_active_input and not self.ignore_cec)
+            or (
+                self.cast_type == CAST_TYPE_CHROMECAST
+                and not self.status.is_active_input
+                and not self.ignore_cec
+            )
         )
 
     @property

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -1053,7 +1053,7 @@ class ReceiverController(BaseController):
             Will only launch if it is not currently running unless
             force_launch=True. """
 
-        if not force_launch and self.app_id is None:
+        if not force_launch and self.status is None:
             self.update_status(
                 lambda response: self._send_launch_message(
                     app_id, force_launch, callback_function


### PR DESCRIPTION
Fix bugs in Chromecast.is_idle and ReceiverController.launch_app:
- Correct Chromecast.is_idle return value for ChromeCastAudio and speaker groups
- ReceiverController.launch_app should not request a redundant status update if no app is launched