### PR TITLE
Log as info, not warning if connection re-established.

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -370,7 +370,7 @@ class SocketClient(threading.Thread):
                             self.port,
                         )
                     else:
-                        self.logger.warning(
+                        self.logger.info(
                             "[%s(%s):%s] Connection reestablished!",
                             self.fn or "",
                             self.host,


### PR DESCRIPTION
Change log level of reconnect message.