### PR TITLE
Ignore faulty data, making "not iterable" error

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -604,15 +604,18 @@ class SocketClient(threading.Thread):
         # See if any handlers will accept this message
         self._route_message(message, data)
 
-        if REQUEST_ID in data:
-            callback = self._request_callbacks.pop(data[REQUEST_ID], None)
-            if callback is not None:
-                event = callback["event"]
-                callback["response"] = data
-                function = callback["function"]
-                event.set()
-                if function:
-                    function(data)
+        try:
+          if REQUEST_ID in data:
+              callback = self._request_callbacks.pop(data[REQUEST_ID], None)
+              if callback is not None:
+                  event = callback["event"]
+                  callback["response"] = data
+                  function = callback["function"]
+                  event.set()
+                  if function:
+                      function(data)
+        except:
+          pass # Invalid data. Ignoring
 
         return 0
 

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -604,18 +604,18 @@ class SocketClient(threading.Thread):
         # See if any handlers will accept this message
         self._route_message(message, data)
 
-        try:
-            if REQUEST_ID in data:
-                callback = self._request_callbacks.pop(data[REQUEST_ID], None)
-                if callback is not None:
-                    event = callback["event"]
-                    callback["response"] = data
-                    function = callback["function"]
-                    event.set()
-                    if function:
-                        function(data)
-        except TypeError:
-            pass  # Invalid data. Ignoring
+        if isinstance(data, int):
+            return 0
+
+        if REQUEST_ID in data:
+            callback = self._request_callbacks.pop(data[REQUEST_ID], None)
+            if callback is not None:
+                event = callback["event"]
+                callback["response"] = data
+                function = callback["function"]
+                event.set()
+                if function:
+                    function(data)
 
         return 0
 

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -605,17 +605,17 @@ class SocketClient(threading.Thread):
         self._route_message(message, data)
 
         try:
-          if REQUEST_ID in data:
-              callback = self._request_callbacks.pop(data[REQUEST_ID], None)
-              if callback is not None:
-                  event = callback["event"]
-                  callback["response"] = data
-                  function = callback["function"]
-                  event.set()
-                  if function:
-                      function(data)
-        except:
-          pass # Invalid data. Ignoring
+            if REQUEST_ID in data:
+                callback = self._request_callbacks.pop(data[REQUEST_ID], None)
+                if callback is not None:
+                    event = callback["event"]
+                    callback["response"] = data
+                    function = callback["function"]
+                    event.set()
+                    if function:
+                        function(data)
+        except TypeError:
+            pass  # Invalid data. Ignoring
 
         return 0
 


### PR DESCRIPTION
I live in Denmark, and here the public station "DR" have a chromecast app. When watching a series, and the "Next episode" teaser appears on the TV, python throws an exception.

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/ebbe/code/ebbe/tmp/pychromecast/pychromecast/socket_client.py", line 531, in run
    if self.run_once(timeout=POLL_TIME_BLOCKING) == 1:
  File "/home/ebbe/code/ebbe/tmp/pychromecast/pychromecast/socket_client.py", line 607, in run_once
    if REQUEST_ID in data:
TypeError: argument of type 'int' is not iterable
```

I debugged `data`, and found it sometimes (near the end of an episode) contained integers: 1001 and 1002. This `try` fixes the issue.

Discovered the error through Home Assistant, when it simply stopped being updated (because the python thread had failed).