### PR TITLE
Refactor start_discovery to fix race

### DIFF
--- a/examples/discovery_example.py
+++ b/examples/discovery_example.py
@@ -27,7 +27,8 @@ def remove_callback(name, service):
     print("Lost cast device {} {}".format(name, service))
     list_devices()
 
-listener, browser = pychromecast.discovery.start_discovery(add_callback, remove_callback)
+listener = pychromecast.CastListener(add_callback, remove_callback)
+browser = pychromecast.discovery.start_discovery(listener)
 
 try:
     while True:

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -12,6 +12,7 @@ from .error import *  # noqa
 from . import socket_client
 from .discovery import (
     DISCOVER_TIMEOUT,
+    CastListener,
     discover_chromecasts,
     start_discovery,
     stop_discovery,
@@ -207,7 +208,8 @@ def get_chromecasts(
         """Stops discovery of new chromecasts."""
         stop_discovery(browser)
 
-    listener, browser = start_discovery(internal_callback)
+    listener = CastListener(internal_callback)
+    browser = start_discovery(listener)
     return internal_stop
 
 

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -94,12 +94,7 @@ class CastListener:
             callback(name)
 
 
-def start_discovery(
-    add_callback=None,
-    remove_callback=None,
-    update_callback=None,
-    zeroconf_instance=None,
-):
+def start_discovery(listener, zeroconf_instance=None):
     """
     Start discovering chromecasts on the network.
 
@@ -108,28 +103,31 @@ def start_discovery(
     discovered chromecast's zeroconf name. This is the dictionary key to find
     the chromecast metadata in listener.services.
 
-    This method returns the CastListener object and the zeroconf ServiceBrowser
-    object. The CastListener object will contain information for the discovered
-    chromecasts. To stop discovery, call the stop_discovery method with the
-    ServiceBrowser object.
+    This method returns the zeroconf ServiceBrowser object.
+
+    A CastListener object must be passed, and will contain information for the
+    discovered chromecasts. To stop discovery, call the stop_discovery method with
+    the ServiceBrowser object.
 
     A shared zeroconf instance can be passed as zeroconf_instance. If no
     instance is passed, a new instance will be created.
     """
-    listener = CastListener(add_callback, remove_callback, update_callback)
     return (
-        listener,
         zeroconf.ServiceBrowser(
             zeroconf_instance or zeroconf.Zeroconf(),
             "_googlecast._tcp.local.",
             listener,
-        ),
+        )
     )
 
 
 def stop_discovery(browser):
     """Stop the chromecast discovery thread."""
-    browser.cancel()
+    try:
+        browser.cancel()
+    except RuntimeError:
+        # Throws if called from service callback when joining the zc browser thread
+        pass
     browser.zc.close()
 
 
@@ -143,7 +141,8 @@ def discover_chromecasts(max_devices=None, timeout=DISCOVER_TIMEOUT):
                 discover_complete.set()
 
         discover_complete = Event()
-        listener, browser = start_discovery(callback)
+        listener = CastListener(callback)
+        browser = start_discovery(listener)
 
         # Wait for the timeout or the maximum number of devices
         discover_complete.wait(timeout)

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -112,12 +112,8 @@ def start_discovery(listener, zeroconf_instance=None):
     A shared zeroconf instance can be passed as zeroconf_instance. If no
     instance is passed, a new instance will be created.
     """
-    return (
-        zeroconf.ServiceBrowser(
-            zeroconf_instance or zeroconf.Zeroconf(),
-            "_googlecast._tcp.local.",
-            listener,
-        )
+    return zeroconf.ServiceBrowser(
+        zeroconf_instance or zeroconf.Zeroconf(), "_googlecast._tcp.local.", listener,
     )
 
 


### PR DESCRIPTION
Prevent a race in `start_discovery` where callbacks arrive before the listener is returned.

Fix for home-assistant/core#36326