### PR TITLE
include host for returned devices

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -70,7 +70,7 @@ def get_chromecast_from_service(
     # Build device status from the mDNS service name info, this
     # information is the primary source and the remaining will be
     # fetched later on.
-    services, uuid, model_name, friendly_name = services
+    host, services, uuid, model_name, friendly_name = services
     _LOGGER.debug("_get_chromecast_from_service %s", services)
     cast_type = CAST_TYPES.get(model_name.lower(), CAST_TYPE_CHROMECAST)
     manufacturer = CAST_MANUFACTURERS.get(model_name.lower(), "Google Inc.")
@@ -82,7 +82,7 @@ def get_chromecast_from_service(
         cast_type=cast_type,
     )
     return Chromecast(
-        host=None,
+        host=host,
         device=device,
         tries=tries,
         timeout=timeout,

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -99,11 +99,16 @@ class CastListener:
             return
         uuid = UUID(uuid)
 
+        hosts = service.parsed_addresses()
+        if len(hosts):
+            host = hosts[0]
+
         services_for_uuid = self.services.setdefault(
             uuid, ({name}, uuid, model_name, friendly_name)
         )
         services_for_uuid[0].add(name)
         self.services[uuid] = (
+            host,
             services_for_uuid[0],
             services_for_uuid[1],
             model_name,

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -100,7 +100,7 @@ class CastListener:
         uuid = UUID(uuid)
 
         hosts = service.parsed_addresses()
-        if len(hosts):
+        if len(hosts) > 0:
             host = hosts[0]
 
         services_for_uuid = self.services.setdefault(

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -100,8 +100,7 @@ class CastListener:
         uuid = UUID(uuid)
 
         hosts = service.parsed_addresses()
-        if len(hosts) > 0:
-            host = hosts[0]
+        host = hosts[0] if len(hosts) > 0 else None
 
         services_for_uuid = self.services.setdefault(
             uuid, ({name}, uuid, model_name, friendly_name)


### PR DESCRIPTION
The recent release of version 7 did not include host name for the discovered devices. I have tried to reintroduce this feature with this PR in a similar way to what existed before this release.