### PR TITLE
update_status of MediaController after connect

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -358,6 +358,7 @@ class SocketClient(threading.Thread):
                         )
                     )
                     self.receiver_controller.update_status()
+                    self.media_controller.update_status()
                     self.heartbeat_controller.ping()
                     self.heartbeat_controller.reset()
 


### PR DESCRIPTION
I think it makes sense to update the media status after connection, otherwise listeners from users wouldn't be called and old values may remain.
Please test this change before merge as I can't test with my devices at the moment.