### PR TITLE
Remove reboot function

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -440,10 +440,6 @@ class Chromecast:
 
         self.socket_client.receiver_controller.stop_app()
 
-    def reboot(self):
-        """ Reboots the Chromecast. """
-        reboot(self.host)
-
     def volume_up(self, delta=0.1):
         """ Increment volume by 0.1 (or delta) unless it is already maxed.
         Returns the new volume.

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -20,7 +20,7 @@ from .discovery import (  # noqa
     start_discovery,
     stop_discovery,
 )
-from .dial import get_device_status, reboot, DeviceStatus
+from .dial import get_device_status, DeviceStatus
 from .const import CAST_MANUFACTURERS, CAST_TYPES, CAST_TYPE_CHROMECAST
 from .controllers.media import STREAM_TYPE_BUFFERED  # noqa
 

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -17,18 +17,6 @@ FORMAT_BASE_URL = "http://{}:8008"
 _LOGGER = logging.getLogger(__name__)
 
 
-def reboot(host):
-    """ Reboots the chromecast. """
-    headers = {"content-type": "application/json"}
-
-    requests.post(
-        FORMAT_BASE_URL.format(host) + "/setup/reboot",
-        data='{"params":"now"}',
-        headers=headers,
-        timeout=10,
-    )
-
-
 def _get_status(host, services, zconf, path):
     """
     :param host: Hostname or ip to fetch status from


### PR DESCRIPTION
Remove `reboot()` function, it doesn't work any more after Google locked down the local API.
See #375 and https://github.com/rithvikvibhu/GHLocalApi/issues/39#issuecomment-644959103