### PR TITLE
support non-blocking reconnect

### DIFF
--- a/examples/asyncio_loop.py
+++ b/examples/asyncio_loop.py
@@ -1,0 +1,113 @@
+"""
+Example that shows how the socket client can be used without its own worker
+thread by not calling Chromecast.start() or Chromecast.wait(), but instead calling
+Chromecast.connect() and use asyncio as main loop.
+"""
+import argparse
+import logging
+import select
+import time
+import asyncio
+
+import pychromecast
+
+CAST_NAME = "Living Room"
+
+"""
+Check for cast.socket_client.get_socket() and
+handle it with cast.socket_client.run_once()
+"""
+
+loop = asyncio.get_event_loop()
+
+async def startChromecast():
+
+    cc = None
+    socketInLoop = 0
+    checkConnectionTask = None
+
+    def ccRunOnce():
+        cc.socket_client.run_once()
+
+    async def checkConnection():
+        nonlocal socketInLoop
+        while True:
+            try:
+                ccRunOnce()
+                if socketInLoop != cc.socket_client.get_socket() and cc.socket_client.is_connected:
+                    # update socket after reconnect
+                    socketInLoop = cc.socket_client.get_socket()
+                    loop.add_reader(socketInLoop, ccRunOnce)
+                socketInLoop = cc.socket_client.get_socket()
+                loop.add_reader(socketInLoop, ccRunOnce)
+            except Exception as e:
+                print("ERROR: run_once: " + str(e))
+            await asyncio.sleep(2)
+
+    async def connectChromecast():
+        nonlocal checkConnectionTask
+        cc.connect()
+        checkConnectionTask = loop.create_task(checkConnection())
+
+    def castFound(chromecast):
+        if chromecast.name == CAST_NAME:
+            print("=> Discovered cast " + CAST_NAME)
+            nonlocal cc
+            cc = chromecast
+            loop.create_task(connectChromecast())
+
+    browser = pychromecast.get_chromecasts(blocking=False, tries=1, retry_wait=0.1, timeout=0.1, callback=castFound)
+
+    while True:
+        if cc is not None and cc.socket_client.is_connected:
+            print("=> Start BigBuckBunny")
+            cc.play_media(
+                (
+                    "http://commondatastorage.googleapis.com/gtv-videos-bucket/"
+                    "sample/BigBuckBunny.mp4"
+                ),
+                "video/mp4",
+            )
+
+            await asyncio.sleep(30)
+            print("=> Pause")
+            cc.media_controller.pause()
+            await asyncio.sleep(5)
+            print("=> Play")
+            cc.media_controller.play()
+            await asyncio.sleep(5)
+            print("=> Stop")
+            cc.media_controller.stop()
+            print("=> Quit App")
+            cc.quit_app()
+
+            # stop the checkConnectionTask before we close asyncio
+            checkConnectionTask.cancel()
+            # stop the discovery of pychromecast
+            pychromecast.stop_discovery(browser)
+            return
+        else:
+            await asyncio.sleep(1)
+
+
+parser = argparse.ArgumentParser(
+    description="Example on how to use the Media Controller to play an URL."
+)
+parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
+parser.add_argument(
+    "--cast", help='Name of cast device (default: "%(default)s")', default=CAST_NAME
+)
+args = parser.parse_args()
+
+if args.show_debug:
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig(level=logging.INFO)
+
+
+try:
+    asyncio.get_event_loop().run_until_complete(startChromecast())
+except KeyboardInterrupt:
+    pass
+finally:
+    loop.close()

--- a/examples/asyncio_loop.py
+++ b/examples/asyncio_loop.py
@@ -55,6 +55,8 @@ async def startChromecast():
             nonlocal cc
             cc = chromecast
             loop.create_task(connectChromecast())
+            # stop the discovery of pychromecast
+            pychromecast.stop_discovery(browser)
 
     browser = pychromecast.get_chromecasts(blocking=False, tries=1, retry_wait=0.1, timeout=0.1, callback=castFound)
 
@@ -83,8 +85,6 @@ async def startChromecast():
 
             # stop the checkConnectionTask before we close asyncio
             checkConnectionTask.cancel()
-            # stop the discovery of pychromecast
-            pychromecast.stop_discovery(browser)
             return
         else:
             await asyncio.sleep(1)

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -65,7 +65,7 @@ _get_chromecast_from_host = get_chromecast_from_host  # pylint: disable=invalid-
 
 
 def get_chromecast_from_service(
-    services, zconf, tries=None, retry_wait=None, timeout=None
+    services, zconf, tries=None, retry_wait=None, timeout=None, blocking=True
 ):
     """Creates a Chromecast object from a zeroconf service."""
     # Build device status from the mDNS service name info, this
@@ -90,6 +90,7 @@ def get_chromecast_from_service(
         retry_wait=retry_wait,
         services=services,
         zconf=zconf,
+        blocking=blocking,
     )
 
 
@@ -238,6 +239,7 @@ def get_chromecasts(
                     tries=tries,
                     retry_wait=retry_wait,
                     timeout=timeout,
+                    blocking=blocking,
                 )
             )
         except ChromecastConnectionError:  # noqa
@@ -279,6 +281,7 @@ class Chromecast:
     """
 
     def __init__(self, host, port=None, device=None, **kwargs):
+        blocking = kwargs.pop("blocking", True)
         tries = kwargs.pop("tries", None)
         timeout = kwargs.pop("timeout", None)
         retry_wait = kwargs.pop("retry_wait", None)
@@ -325,6 +328,7 @@ class Chromecast:
             host,
             port=port,
             cast_type=self.device.cast_type,
+            blocking=blocking,
             tries=tries,
             timeout=timeout,
             retry_wait=retry_wait,

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -65,7 +65,7 @@ _get_chromecast_from_host = get_chromecast_from_host  # pylint: disable=invalid-
 
 
 def get_chromecast_from_service(
-    services, zconf, tries=None, retry_wait=None, timeout=None, blocking=True
+    services, zconf, tries=None, retry_wait=None, timeout=None
 ):
     """Creates a Chromecast object from a zeroconf service."""
     # Build device status from the mDNS service name info, this
@@ -90,7 +90,6 @@ def get_chromecast_from_service(
         retry_wait=retry_wait,
         services=services,
         zconf=zconf,
-        blocking=blocking,
     )
 
 
@@ -239,7 +238,6 @@ def get_chromecasts(
                     tries=tries,
                     retry_wait=retry_wait,
                     timeout=timeout,
-                    blocking=blocking,
                 )
             )
         except ChromecastConnectionError:  # noqa
@@ -281,7 +279,6 @@ class Chromecast:
     """
 
     def __init__(self, host, port=None, device=None, **kwargs):
-        blocking = kwargs.pop("blocking", True)
         tries = kwargs.pop("tries", None)
         timeout = kwargs.pop("timeout", None)
         retry_wait = kwargs.pop("retry_wait", None)
@@ -328,7 +325,6 @@ class Chromecast:
             host,
             port=port,
             cast_type=self.device.cast_type,
-            blocking=blocking,
             tries=tries,
             timeout=timeout,
             retry_wait=retry_wait,
@@ -500,7 +496,7 @@ class Chromecast:
         :param blocking: If True it will block until the disconnection is
                          complete, otherwise it will return immediately.
         """
-        self.socket_client.disconnect()
+        self.socket_client.disconnect(blocking)
         if blocking:
             self.join(timeout=timeout)
 

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -229,7 +229,8 @@ def get_info_from_service(service, zconf):
     """ Resolve service_info from service. """
     service_info = None
     try:
-        service_info = zconf.get_service_info("_googlecast._tcp.local.", service)
+        # add 50ms timeout for non-blocking
+        service_info = zconf.get_service_info("_googlecast._tcp.local.", service, 50)
         if service_info:
             _LOGGER.debug(
                 "get_info_from_service resolved service %s to service_info %s",

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -272,10 +272,10 @@ class SocketClient(threading.Thread):
             retry["delay"] = min(retry["delay"] * 2, 300)
             retries[service] = retry
 
-        if self.blocking == False:
+        if not self.blocking:
             tries = 1
 
-        while (not self.stop.is_set() or self.blocking == False) and (
+        while (not self.stop.is_set() or not self.blocking) and (
             tries is None or tries > 0
         ):  # noqa: E501 pylint:disable=too-many-nested-blocks
             # Prune retries dict
@@ -436,7 +436,7 @@ class SocketClient(threading.Thread):
                 tries -= 1
 
         if self.blocking:
-          self.stop.set()
+            self.stop.set()
         self.logger.error(
             "[%s(%s):%s] Failed to connect. No retries.",
             self.fn or "",
@@ -679,7 +679,7 @@ class SocketClient(threading.Thread):
                 self.initialize_connection()
             except ChromecastConnectionError:
                 if self.blocking:
-                  self.stop.set()
+                    self.stop.set()
             return False
         return True
 


### PR DESCRIPTION
This change allows the usage of run_once() to reconnect the cast device in a non-blocking way. Every run_once() call it just tries to reconnect the device once for timeout period and finishes the function afterwards.