### PR TITLE
Fixed error with Youtube exemple

### DIFF
--- a/examples/youtube_example.py
+++ b/examples/youtube_example.py
@@ -39,7 +39,7 @@ if not chromecasts:
     print('No chromecast with name "{}" discovered'.format(args.cast))
     sys.exit(1)
 
-cast = chromecasts[0]
+cast = list(chromecasts)[0]
 # Start socket client's worker thread and wait for initial status update
 cast.wait()
 


### PR DESCRIPTION
Previous version caused Python to show a "Object is non-subscriptable" error. Converting it to a list fixes the problem.