### PR TITLE
Allow passing additional media information through to play_media

### DIFF
--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -500,6 +500,7 @@ class MediaController(BaseController):
         subtitles_mime="text/vtt",
         subtitle_id=1,
         enqueue=False,
+        media_info=None,
     ):
         """
         Plays media on the Chromecast. Start default media receiver if not
@@ -520,12 +521,14 @@ class MediaController(BaseController):
         subtitles_mime: str - mimetype of subtitles.
         subtitle_id: int - id of subtitle to be loaded.
         enqueue: bool - if True, enqueue the media instead of play it.
+        media_info: dict - additional MediaInformation attributes not explicitly listed.
         metadata: dict - media metadata object, one of the following:
             GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata,
             MusicTrackMediaMetadata, PhotoMediaMetadata.
 
         Docs:
         https://developers.google.com/cast/docs/reference/messages#MediaData
+        https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation
         """
         # pylint: disable=too-many-locals
         def app_launched_callback():
@@ -544,6 +547,7 @@ class MediaController(BaseController):
                 subtitles_mime,
                 subtitle_id,
                 enqueue,
+                media_info,
             )
 
         receiver_ctrl = self._socket_client.receiver_controller
@@ -564,13 +568,16 @@ class MediaController(BaseController):
         subtitles_mime="text/vtt",
         subtitle_id=1,
         enqueue=False,
+        media_info=None,
     ):
         # pylint: disable=too-many-locals
+        media_info = media_info or {}
         media = {
             "contentId": url,
             "streamType": stream_type,
             "contentType": content_type,
             "metadata": metadata or {},
+            **media_info,
         }
 
         if title:


### PR DESCRIPTION
In Home Assistant 0.115 we changed the format of the HLS stream used for showing cameras from MPEG-TS to Fragmented MP4. In order to have chromecast play fmp4 files, we need to forward the `hlsVideoSegmentFormat` option to the device. Since there are additional MediaInformation options, I implemented this in a way to allow other options to also be utilized. See https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.messages.MediaInformation