### PR TITLE
docs: fix simple typo, neeeded -> needed

### DIFF
--- a/pychromecast/controllers/plex.py
+++ b/pychromecast/controllers/plex.py
@@ -59,7 +59,7 @@ def media_to_chromecast_command(
     **kwargs
 ):  # noqa: 501 pylint: disable=invalid-name, too-many-arguments, too-many-locals, protected-access, redefined-builtin
     """Create the message that chromecast requires. Use pass of plexapi media object or
-       set all the neeeded kwargs manually. See the code for what to set.
+       set all the needed kwargs manually. See the code for what to set.
 
     Args:
         media (None, optional): a :class:`~plexapi.base.Playable


### PR DESCRIPTION
There is a small typo in pychromecast/controllers/plex.py.

Should read `needed` rather than `neeeded`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md