### PR TITLE
Refactor listeners and controllers as ABCs

### DIFF
--- a/pychromecast/controllers/__init__.py
+++ b/pychromecast/controllers/__init__.py
@@ -1,12 +1,13 @@
 """
 Provides controllers to handle specific namespaces in Chromecast communication.
 """
+import abc
 import logging
 
 from ..error import UnsupportedNamespace, ControllerNotRegistered
 
 
-class BaseController:
+class BaseController(abc.ABC):
     """ ABC for namespace controllers. """
 
     def __init__(self, namespace, supporting_app_id=None, target_platform=False):

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -2,6 +2,7 @@
 Provides a controller for controlling the default media players
 on the Chromecast.
 """
+import abc
 from datetime import datetime
 import logging
 
@@ -310,6 +311,14 @@ class MediaStatus:
         return "<MediaStatus {}>".format(info)
 
 
+class MediaStatusListener(abc.ABC):
+    """Listener for receiving media status events."""
+
+    @abc.abstractmethod
+    async def new_media_status(self, status: MediaStatus):
+        """Updated media status."""
+
+
 # pylint: disable=too-many-public-methods
 class MediaController(BaseController):
     """ Controller to interact with Google media namespace. """
@@ -341,7 +350,7 @@ class MediaController(BaseController):
 
         return False
 
-    def register_status_listener(self, listener):
+    def register_status_listener(self, listener: MediaStatusListener):
         """Register a listener for new media statuses. A new status will
         call listener.new_media_status(status)"""
         self._status_listeners.append(listener)

--- a/pychromecast/controllers/multizone.py
+++ b/pychromecast/controllers/multizone.py
@@ -105,7 +105,9 @@ class MultiZoneManagerListener(abc.ABC):
         """The cast has been removed from group identified by group_uuid."""
 
     @abc.abstractmethod
-    async def multizone_new_media_status(self, group_uuid: str, media_status: MediaStatus):
+    async def multizone_new_media_status(
+        self, group_uuid: str, media_status: MediaStatus
+    ):
         """The group identified by group_uuid, of which the cast is a member, has new media status."""
 
     @abc.abstractmethod
@@ -182,7 +184,9 @@ class MultiZoneControllerListener(abc.ABC):
         """The cast has been removed from group identified by group_uuid."""
 
     @abc.abstractmethod
-    async def multizone_status_received(self, group_uuid: str, media_status: MediaStatus):
+    async def multizone_status_received(
+        self, group_uuid: str, media_status: MediaStatus
+    ):
         """The group identified by group_uuid, of which the cast is a member, has new status."""
 
 

--- a/pylintrc
+++ b/pylintrc
@@ -5,6 +5,7 @@ reports=no
 disable=
   format,
   locally-disabled,
+  too-few-public-methods,
   too-many-arguments,
   too-many-instance-attributes,
   too-many-public-methods,


### PR DESCRIPTION
Refactor listeners and controllers as ABCs

**Breaking**: This is mainly to make the library easier to use by making the interface clearer, but may be a breaking change in some situations