### PR TITLE
Infer contentType from playQueue items

### DIFF
--- a/pychromecast/controllers/plex.py
+++ b/pychromecast/controllers/plex.py
@@ -115,7 +115,7 @@ def media_to_chromecast_command(
 
         playQueueID = playQueue.playQueueID
         contentId = playQueue.selectedItem.key
-        contentType = playQueue.playQueueType
+        contentType = playQueue.items[0].listType
         version = server.version
 
     # Chromecasts seem to start playback 5 seconds before the offset.


### PR DESCRIPTION
PlexAPI now has a getPlayQueue method that grabs the playQueue from server. This is now used in a [new service to play a playQueue](https://github.com/home-assistant/core/pull/45580) on plex capable media_players in HA 2021.2.0b1 (google cast devices, sonos, and plex clients). This fixes that service failing with:

`AttributeError: 'PlayQueue' object has no attribute 'playQueueType'`

playQueues from server have no playQueueType only PlexAPI playQueues have that attribute.