### PR TITLE
Handle audio groups removed from known host

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -267,7 +267,7 @@ class SocketClient(threading.Thread):
             # Prune retries dict
             retries = {
                 key: retries[key]
-                for key in self.services
+                for key in self.services.copy()
                 if (key is not None and key in retries)
             }
 


### PR DESCRIPTION
Fix purging of host based services when a host is still up, but the UUIDs it handles changes.
This handles audio groups removed from a known host, but would also handle the case where cast devices swap IPs.

Also make sure only one thread is modifying the dict of known cast devices at the same time.

Fixes #473 