### PR TITLE
Handle bad UUIDs from third-party Chromecasts

### DIFF
--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -167,7 +167,7 @@ class ZeroConfListener:
         # Handle incorrect UUIDs from third-party Chromecast emulators
         try:
             uuid = UUID(uuid)
-        except ValueError as e:
+        except ValueError:
             _LOGGER.debug(
                 "_add_update_service failed due to bad uuid for %s, %s, model %s",
                 typ,

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -163,7 +163,18 @@ class ZeroConfListener:
                 "_add_update_service failed to get uuid for %s, %s", typ, name
             )
             return
-        uuid = UUID(uuid)
+
+        # Handle incorrect UUIDs from third-party Chromecast emulators
+        try:
+            uuid = UUID(uuid)
+        except ValueError as e:
+            _LOGGER.debug(
+                "_add_update_service failed due to bad uuid for %s, %s, model %s",
+                typ,
+                name,
+                model_name,
+            )
+            return
 
         service_info = ServiceInfo(SERVICE_TYPE_MDNS, name)
 

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -164,7 +164,7 @@ class ZeroConfListener:
             )
             return
 
-        # Handle incorrect UUIDs from third-party Chromecast emulators
+        # Ignore incorrect UUIDs from third-party Chromecast emulators
         try:
             uuid = UUID(uuid)
         except ValueError:


### PR DESCRIPTION
Certain third-party Chromecast emulators like Reflector 4 broadcast bad UUIDs, which results in the entire pychromecast module failing to discover any devices when they're on the same network. This resolves the issue by ignoring said devices.

This also resolves issue #288.

For reference, this is the error message that pychromecast generates:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.8/site-packages/zeroconf/__init__.py", line 1755, in run
    self._service_state_changed.fire(
  File "/usr/local/lib/python3.8/site-packages/zeroconf/__init__.py", line 1513, in fire
    h(**kwargs)
  File "/usr/local/lib/python3.8/site-packages/zeroconf/__init__.py", line 1611, in on_change
    listener.add_service(*args)
  File "/usr/local/lib/python3.8/site-packages/pychromecast/discovery.py", line 65, in add_service
    self._add_update_service(zconf, typ, name, self.add_callback)
  File "/usr/local/lib/python3.8/site-packages/pychromecast/discovery.py", line 107, in _add_update_service
    uuid = UUID(uuid)
  File "/usr/local/lib/python3.8/uuid.py", line 171, in __init__
    raise ValueError('badly formed hexadecimal UUID string')
ValueError: badly formed hexadecimal UUID string
```