### PR TITLE
Fix spotify controller and update example

### DIFF
--- a/examples/spotify_example.py
+++ b/examples/spotify_example.py
@@ -114,8 +114,9 @@ headers = {
     "Authorization": "Bearer " + access_token,
 }
 transferResponse = requests.post(
-    "https://guc-spclient.spotify.com/connect-state/v1/connect/transfer/from/noop/to/"
-    + sp.device,
+    "https://guc-spclient.spotify.com/connect-state/v1/connect/transfer/from/noop/to/{}".format(
+        sp.device
+    ),
     headers=headers,
 )
 

--- a/examples/spotify_example.py
+++ b/examples/spotify_example.py
@@ -97,6 +97,8 @@ if not sp.is_launched and sp.credential_error:
     print("Failed to launch spotify controller due to credential error")
     sys.exit(1)
 
+# The chromecast device does not show up as part of the public API get devices call
+# The only way to transfer playback to a chromcast devicew is by calling this non public API
 headers = {
     'Accept': 'application/json',
     'Content-Type': 'application/json',

--- a/examples/spotify_example.py
+++ b/examples/spotify_example.py
@@ -97,14 +97,19 @@ if not sp.is_launched and sp.credential_error:
     print("Failed to launch spotify controller due to credential error")
     sys.exit(1)
 
-# The chromecast device does not show up as part of the public API get devices call
-# The only way to transfer playback to a chromcast devicew is by calling this non public API
+# The chromecast device does not show up as part of the public API get devices
+# call until it starts playing. The only way to do so is to transfer playback
+# by call this endpoint that's not part of their public API.
 headers = {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-    'Authorization': 'Bearer ' + access_token,
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Authorization": "Bearer " + access_token,
 }
-transferResponse = requests.post('https://guc-spclient.spotify.com/connect-state/v1/connect/transfer/from/noop/to/' + sp.device, headers=headers)
+transferResponse = requests.post(
+    "https://guc-spclient.spotify.com/connect-state/v1/connect/transfer/from/noop/to/"
+    + sp.device,
+    headers=headers,
+)
 
 if transferResponse.status_code is not 200:
     print("Failed to transfer playback to chromecast device")

--- a/examples/spotify_example.py
+++ b/examples/spotify_example.py
@@ -38,8 +38,16 @@ parser.add_argument("--show-debug", help="Enable debug log", action="store_true"
 parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
-parser.add_argument("--sp-key", help="Spotify cookie", required=True)
-parser.add_argument("--sp-dc", help="Spotify cookie", required=True)
+parser.add_argument(
+    "--sp-key",
+    help="Spotify cookie, as per https://github.com/enriquegh/spotify-webplayer-token#usage",
+    required=True,
+)
+parser.add_argument(
+    "--sp-dc",
+    help="Spotify cookie, as per https://github.com/enriquegh/spotify-webplayer-token#usage",
+    required=True,
+)
 parser.add_argument(
     "--uri",
     help='Spotify uri(s) (default: "%(default)s")',

--- a/examples/spotify_example.py
+++ b/examples/spotify_example.py
@@ -120,7 +120,7 @@ transferResponse = requests.post(
     headers=headers,
 )
 
-if transferResponse.status_code is not 200:
+if transferResponse.status_code != 200:
     print("Failed to transfer playback to chromecast device")
     sys.exit(1)
 


### PR DESCRIPTION
It seems the `setCredentials` message has changed to `addUser` at some point in the past, with a different payload.

We also discovered a new issue with playback (on our google homes and chromecasts at least) where launching the spotify app and adding the user/token to it doesn't cause it to appear in spotify's device list. This updates the example to make the same request the web player does to enable playback on the cast device.