### PR TITLE
Spotcast fix: Remove uneeded SET_CREDENTIALS steps

### DIFF
--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -44,18 +44,8 @@ class SpotifyController(BaseController):
             self.client = data["payload"]["clientID"]
             headers = {
                 'authority': 'spclient.wg.spotify.com',
-                'sec-ch-ua': '"Chromium";v="92", " Not A;Brand";v="99", "Google Chrome";v="92"',
                 'authorization': 'Bearer {}'.format(self.access_token),
-                'sec-ch-ua-mobile': '?0',
-                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36',
-                'content-type': 'text/plain;charset=UTF-8',
-                'accept': '*/*',
-                'origin': 'https://open.spotify.com',
-                'sec-fetch-site': 'same-site',
-                'sec-fetch-mode': 'cors',
-                'sec-fetch-dest': 'empty',
-                'referer': 'https://open.spotify.com/',
-                'accept-language': 'en-US,en;q=0.9',
+                'content-type': 'text/plain;charset=UTF-8'
             }
 
             request_body = json.dumps({'clientId': self.client, 'deviceId': self.device})

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -15,6 +15,7 @@ TYPE_GET_INFO = "getInfo"
 TYPE_GET_INFO_RESPONSE = "getInfoResponse"
 TYPE_ADD_USER = "addUser"
 TYPE_ADD_USER_RESPONSE = "addUserResponse"
+TYPE_ADD_USER_ERROR = "addUserError"
 
 
 # pylint: disable=too-many-instance-attributes
@@ -61,6 +62,11 @@ class SpotifyController(BaseController):
             })
         if data["type"] == TYPE_ADD_USER_RESPONSE:
             self.is_launched = True
+            self.waiting.set()
+
+        if data["type"] == TYPE_ADD_USER_ERROR:
+            self.device = None
+            self.credential_error = True
             self.waiting.set()
         return True
 

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -11,9 +11,6 @@ from ..error import LaunchError
 APP_NAMESPACE = "urn:x-cast:com.spotify.chromecast.secure.v1"
 TYPE_GET_INFO = "getInfo"
 TYPE_GET_INFO_RESPONSE = "getInfoResponse"
-TYPE_SET_CREDENTIALS = "setCredentials"
-TYPE_SET_CREDENTIALS_ERROR = "setCredentialsError"
-TYPE_SET_CREDENTIALS_RESPONSE = "setCredentialsResponse"
 
 
 # pylint: disable=too-many-instance-attributes
@@ -38,12 +35,6 @@ class SpotifyController(BaseController):
 
         Called when a message is received.
         """
-        if data["type"] == TYPE_SET_CREDENTIALS_RESPONSE:
-            self.send_message({"type": TYPE_GET_INFO, "payload": {}})
-        if data["type"] == TYPE_SET_CREDENTIALS_ERROR:
-            self.device = None
-            self.credential_error = True
-            self.waiting.set()
         if data["type"] == TYPE_GET_INFO_RESPONSE:
             self.device = data["payload"]["deviceID"]
             self.is_launched = True
@@ -63,13 +54,7 @@ class SpotifyController(BaseController):
 
         def callback():
             """Callback function"""
-            self.send_message(
-                {
-                    "type": TYPE_SET_CREDENTIALS,
-                    "credentials": self.access_token,
-                    "expiresIn": self.expires,
-                }
-            )
+            self.send_message({"type": TYPE_GET_INFO, "payload": {}})
 
         self.device = None
         self.credential_error = False


### PR DESCRIPTION
This is an attempt to fix https://github.com/home-assistant-libs/pychromecast/issues/520

I noticed that we were no longer receiving a setCredentialsResponse so I decided to try and remove that step and it seemed to work. 

Open to a stronger fix, but this seems to work for me.