### PR TITLE
Remove unnecessary app launch in quickplay

### DIFF
--- a/pychromecast/quick_play.py
+++ b/pychromecast/quick_play.py
@@ -71,8 +71,4 @@ def quick_play(cast, app_name, data):
 
     cast.register_handler(controller)
 
-    def app_launched_callback():
-        """Plays media after chromecast has switched to requested app."""
-        controller.quick_play(**data)
-
-    controller.launch(callback_function=app_launched_callback)
+    controller.quick_play(**data)


### PR DESCRIPTION
Remove unnecessary app launch in quickplay, the app is automatically launched when attempting to send a message for the app.

This somehow broke the Youtube controller when playing through `quick_play()`, there's probably something else wrong in the Youtube controller.

Related issues:
 - https://github.com/home-assistant/core/issues/53882
 - https://github.com/home-assistant/core/issues/53215