### PR TITLE
Include mac_address in DeviceStatus

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ How to use
     >> # Start worker thread and wait for cast device to be ready
     >> cast.wait()
     >> print(cast.device)
-    DeviceStatus(friendly_name='Living Room', model_name='Chromecast', manufacturer='Google Inc.', uuid=UUID('df6944da-f016-4cb8-97d0-3da2ccaa380b'), cast_type='cast')
+    DeviceStatus(friendly_name='Living Room', model_name='Chromecast', manufacturer='Google Inc.', uuid=UUID('df6944da-f016-4cb8-97d0-3da2ccaa380b'), cast_type='cast', mac_address=None)
 
     >> print(cast.status)
     CastStatus(is_active_input=True, is_stand_by=False, volume_level=1.0, volume_muted=False, app_id='CC1AD845', display_name='Default Media Receiver', namespaces=['urn:x-cast:com.google.cast.player.message', 'urn:x-cast:com.google.cast.media'], session_id='CCA39713-9A4F-34A6-A8BF-5D97BE7ECA5C', transport_id='web-9', status_text='')

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -50,6 +50,7 @@ def get_chromecast_from_host(host, tries=None, retry_wait=None, timeout=None):
         manufacturer=manufacturer,
         uuid=uuid,
         cast_type=cast_type,
+        mac_address=None,
     )
     return Chromecast(
         host=ip_address,
@@ -320,6 +321,7 @@ class Chromecast:
                     manufacturer=(device.manufacturer or dev_status.manufacturer),
                     uuid=(device.uuid or dev_status.uuid),
                     cast_type=(device.cast_type or dev_status.cast_type),
+                    mac_address=(device.mac_address or dev_status.mac_address),
                 )
             else:
                 self.device = device

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -119,6 +119,12 @@ def get_device_status(host, services=None, zconf=None, timeout=10, context=None)
         friendly_name = status.get("name", "Unknown Chromecast")
         model_name = "Unknown model name"
         manufacturer = "Unknown manufacturer"
+
+        mac_address = status.get("mac_address", None)
+        # Some devices will return an invalid / placeholder mac_address
+        if mac_address == "00:00:00:00:00:00":
+            mac_address = None
+
         if "detail" in status:
             model_name = status["detail"].get("model_name", model_name)
             manufacturer = status["detail"].get("manufacturer", manufacturer)
@@ -131,7 +137,9 @@ def get_device_status(host, services=None, zconf=None, timeout=10, context=None)
         if udn:
             uuid = UUID(udn.replace("-", ""))
 
-        return DeviceStatus(friendly_name, model_name, manufacturer, uuid, cast_type)
+        return DeviceStatus(
+            friendly_name, model_name, manufacturer, uuid, cast_type, mac_address
+        )
 
     except (urllib.error.HTTPError, urllib.error.URLError, OSError, ValueError):
         return None
@@ -198,5 +206,6 @@ MultizoneInfo = namedtuple("MultizoneInfo", ["friendly_name", "uuid", "host", "p
 MultizoneStatus = namedtuple("MultizoneStatus", ["dynamic_groups", "groups"])
 
 DeviceStatus = namedtuple(
-    "DeviceStatus", ["friendly_name", "model_name", "manufacturer", "uuid", "cast_type"]
+    "DeviceStatus",
+    ["friendly_name", "model_name", "manufacturer", "uuid", "cast_type", "mac_address"],
 )


### PR DESCRIPTION
Including the mac_address within the DeviceStatus object allows
for filling out the Home Assistant device registry `connections`
field, which in turn will allow for de-duplicating these devices
across multiple integrations.