### PR TITLE
Instantiate metadataType when metadata is provided

### DIFF
--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -594,6 +594,12 @@ class MediaController(BaseController):
                 media["metadata"]["images"] = []
 
             media["metadata"]["images"].append({"url": thumb})
+
+        # Need to set metadataType if not specified
+        # https://developers.google.com/cast/docs/reference/messages#MediaInformation
+        if media["metadata"] and "metadataType" not in media["metadata"]:
+            media["metadata"]["metadataType"] = METADATA_TYPE_GENERIC
+
         if subtitles:
             sub_msg = [
                 {
@@ -612,11 +618,6 @@ class MediaController(BaseController):
                 "edgeType": "OUTLINE",
                 "edgeColor": "#000000FF",
             }
-
-        # if user has specified metadata but not specified metadataType
-        # https://developers.google.com/cast/docs/reference/messages#MediaInformation
-        if media["metadata"] and "metadataType" not in media["metadata"]:
-            media["metadata"]["metadataType"] = METADATA_TYPE_GENERIC
 
         if enqueue:
             msg = {

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -612,12 +612,12 @@ class MediaController(BaseController):
                 "edgeType": "OUTLINE",
                 "edgeColor": "#000000FF",
             }
-           
+
         # if user has specified metadata but not specified metadataType
         # https://developers.google.com/cast/docs/reference/messages#MediaInformation
         if media["metadata"].keys() and "metadataType" not in media["metadata"]:
             media["metadata"]["metadataType"] = METADATA_TYPE_GENERIC
-            
+
         if enqueue:
             msg = {
                 "mediaSessionId": self.status.media_session_id,

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -615,7 +615,7 @@ class MediaController(BaseController):
 
         # if user has specified metadata but not specified metadataType
         # https://developers.google.com/cast/docs/reference/messages#MediaInformation
-        if media["metadata"].keys() and "metadataType" not in media["metadata"]:
+        if media["metadata"] and "metadataType" not in media["metadata"]:
             media["metadata"]["metadataType"] = METADATA_TYPE_GENERIC
 
         if enqueue:

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -612,7 +612,12 @@ class MediaController(BaseController):
                 "edgeType": "OUTLINE",
                 "edgeColor": "#000000FF",
             }
-
+           
+        # if user has specified metadata but not specified metadataType
+        # https://developers.google.com/cast/docs/reference/messages#MediaInformation
+        if media["metadata"].keys() and "metadataType" not in media["metadata"]:
+            media["metadata"]["metadataType"] = METADATA_TYPE_GENERIC
+            
         if enqueue:
             msg = {
                 "mediaSessionId": self.status.media_session_id,


### PR DESCRIPTION
from testing and general usage, chromecast expects MetadataType to be provided when passing other metadata fields.

Given callers can either pass minor metadata fields such as title/thumb or a fully custom defined metadata dict, this change simple checks and instantiates the MetadataType field if it's not provided and user wants to provide media metadata. 

Proposal, allow the passing of the metadatatype via explicit function argument in case users' use case require the setting of this field. 