### PR TITLE
Refactor handling of discovered casts and device info

### DIFF
--- a/examples/dashcast_example.py
+++ b/examples/dashcast_example.py
@@ -54,7 +54,7 @@ d = dashcast.DashCastController()
 cast.register_handler(d)
 
 print()
-print(cast.device)
+print(cast.cast_info)
 time.sleep(1)
 print()
 print(cast.status)

--- a/examples/get_chromecasts.py
+++ b/examples/get_chromecasts.py
@@ -41,5 +41,5 @@ if len(casts) == 0:
 print("Found cast devices:")
 for cast in casts:
     print(
-        f'  "{cast.name}" on mDNS service {cast._services} with UUID:{cast.uuid}'  # pylint: disable=protected-access
+        f'  "{cast.name}" on mDNS/host service {cast.cast_info.services} with UUID:{cast.uuid}'  # pylint: disable=protected-access
     )

--- a/examples/media_example2.py
+++ b/examples/media_example2.py
@@ -65,7 +65,7 @@ cast = chromecasts[0]
 cast.wait()
 
 print()
-print(cast.device)
+print(cast.cast_info)
 time.sleep(1)
 print()
 print(cast.status)

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -257,13 +257,14 @@ class Chromecast:
     :param retry_wait: A floating point number specifying how many seconds to
                        wait between each retry. None means to use the default
                        which is 5 seconds.
-    :param zconf: A zeroconf instance, needed if a list of services is passed.
+    :param zconf: A zeroconf instance, needed if a the services if cast info includes
+                  mDNS services.
                   The zeroconf instance may be obtained from the browser returned by
                   pychromecast.start_discovery().
     """
 
     def __init__(
-        self, *, cast_info=None, tries=None, timeout=None, retry_wait=None, zconf=None
+        self, cast_info, *, tries=None, timeout=None, retry_wait=None, zconf=None
     ):
         self.logger = logging.getLogger(__name__)
 

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -46,7 +46,9 @@ def get_chromecast_from_host(host, tries=None, retry_wait=None, timeout=None):
     _LOGGER.debug("get_chromecast_from_host %s", host)
     port = port or 8009
     services = [ServiceInfo(SERVICE_TYPE_HOST, (ip_address, port))]
-    cast_info = CastInfo(services, uuid, model_name, friendly_name, ip_address, port, None, None)
+    cast_info = CastInfo(
+        services, uuid, model_name, friendly_name, ip_address, port, None, None
+    )
     return Chromecast(
         cast_info=cast_info,
         tries=tries,
@@ -260,7 +262,9 @@ class Chromecast:
                   pychromecast.start_discovery().
     """
 
-    def __init__(self, *, cast_info=None, tries=None, timeout=None, retry_wait=None, zconf=None):
+    def __init__(
+        self, *, cast_info=None, tries=None, timeout=None, retry_wait=None, zconf=None
+    ):
         self.logger = logging.getLogger(__name__)
 
         if not cast_info.cast_type:

--- a/pychromecast/const.py
+++ b/pychromecast/const.py
@@ -8,22 +8,6 @@ CAST_TYPE_AUDIO = "audio"
 # Cast Audio group device, supports only audio
 CAST_TYPE_GROUP = "group"
 
-MF_GOOGLE = "Google Inc."
-
-CAST_TYPES = {
-    "chromecast": CAST_TYPE_CHROMECAST,
-    "eureka dongle": CAST_TYPE_CHROMECAST,
-    "chromecast audio": CAST_TYPE_AUDIO,
-    "google home": CAST_TYPE_AUDIO,
-    "google home mini": CAST_TYPE_AUDIO,
-    "google nest mini": CAST_TYPE_AUDIO,
-    "nest audio": CAST_TYPE_AUDIO,
-    "google cast group": CAST_TYPE_GROUP,
-}
-
-# Known models not manufactured by Google
-CAST_MANUFACTURERS = {}
-
 SERVICE_TYPE_HOST = "host"
 SERVICE_TYPE_MDNS = "mdns"
 

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -17,6 +17,7 @@ from .const import (
     CAST_TYPE_GROUP,
     SERVICE_TYPE_HOST,
 )
+from .models import CastInfo, ServiceInfo
 
 XML_NS_UPNP_DEVICE = "{urn:schemas-upnp-org:device-1-0}"
 
@@ -63,20 +64,14 @@ def _get_host_from_zc_service_info(service_info: zeroconf.ServiceInfo):
     return (host, port)
 
 
-def _get_status(host, services, zconf, path, secure, timeout, context):
-    """
-    :param host: Hostname or ip to fetch status from
-    :type host: str
-    :return: The device status as a named tuple.
-    :rtype: pychromecast.dial.DeviceStatus or None
-    """
+def _get_status(services, zconf, path, secure, timeout, context):
+    """Query a cast device via http(s)."""
 
-    if not host:
-        for service in services.copy():
-            host, _, _ = get_host_from_service(service, zconf)
-            if host:
-                _LOGGER.debug("Resolved service %s to %s", service, host)
-                break
+    for service in services.copy():
+        host, _, _ = get_host_from_service(service, zconf)
+        if host:
+            _LOGGER.debug("Resolved service %s to %s", service, host)
+            break
 
     headers = {"content-type": "application/json"}
 
@@ -102,8 +97,49 @@ def get_ssl_context():
     return context
 
 
-def get_device_status(  # pylint: disable=too-many-locals
-    host, services=None, zconf=None, timeout=30, context=None
+def get_cast_type(
+    cast_info, zconf=None, timeout=30, context=None
+):
+    """
+    :param cast_info: cast_info
+    :return: An updated cast_info with filled cast_type
+    :rtype: pychromecast.models.CastInfo
+    """
+    cast_type = CAST_TYPE_CHROMECAST
+    manufacturer = "Unknown manufacturer"
+    if cast_info.port != 8009:
+        cast_type = CAST_TYPE_GROUP
+        manufacturer = "Google Inc."
+    else:
+        try:
+            display_supported = True
+            status = _get_status(
+                cast_info.services,
+                zconf,
+                "/setup/eureka_info?params=device_info,name",
+                True,
+                timeout,
+                context,
+            )
+            if "device_info" in status:
+                device_info = status["device_info"]
+
+                capabilities = device_info.get("capabilities", {})
+                display_supported = capabilities.get("display_supported", True)
+                manufacturer = device_info.get("manufacturer", manufacturer)
+
+            if not display_supported:
+                cast_type = CAST_TYPE_AUDIO
+            _LOGGER.debug("cast type: %s, manufacturer: %s", cast_type, manufacturer)
+
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, ValueError):
+            _LOGGER.warning("Failed to determine cast type")
+            cast_type = CAST_TYPE_CHROMECAST
+
+    return CastInfo(cast_info.services, cast_info.uuid, cast_info.model_name, cast_info.friendly_name, cast_info.host, cast_info.port, cast_type, manufacturer)
+
+def get_device_info(  # pylint: disable=too-many-locals
+    host, zconf=None, timeout=30, context=None
 ):
     """
     :param host: Hostname or ip to fetch status from
@@ -113,8 +149,8 @@ def get_device_status(  # pylint: disable=too-many-locals
     """
 
     try:
+        services = [ServiceInfo(SERVICE_TYPE_HOST, (host, 8009))]
         status = _get_status(
-            host,
             services,
             zconf,
             "/setup/eureka_info?params=device_info,name",
@@ -144,8 +180,6 @@ def get_device_status(  # pylint: disable=too-many-locals
 
         if not display_supported:
             cast_type = CAST_TYPE_AUDIO
-        if model_name.lower() == "google cast group":
-            cast_type = CAST_TYPE_GROUP
 
         uuid = None
         if udn:
@@ -185,7 +219,7 @@ def _get_group_info(host, group):
     return MultizoneInfo(name, uuid, leader_host, leader_port)
 
 
-def get_multizone_status(host, services=None, zconf=None, timeout=30, context=None):
+def get_multizone_status(host, zconf=None, timeout=30, context=None):
     """
     :param host: Hostname or ip to fetch status from
     :type host: str
@@ -194,8 +228,8 @@ def get_multizone_status(host, services=None, zconf=None, timeout=30, context=No
     """
 
     try:
+        services = [ServiceInfo(SERVICE_TYPE_HOST, (host, 8009))]
         status = _get_status(
-            host,
             services,
             zconf,
             "/setup/eureka_info?params=multizone",

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -97,9 +97,7 @@ def get_ssl_context():
     return context
 
 
-def get_cast_type(
-    cast_info, zconf=None, timeout=30, context=None
-):
+def get_cast_type(cast_info, zconf=None, timeout=30, context=None):
     """
     :param cast_info: cast_info
     :return: An updated cast_info with filled cast_type
@@ -136,7 +134,17 @@ def get_cast_type(
             _LOGGER.warning("Failed to determine cast type")
             cast_type = CAST_TYPE_CHROMECAST
 
-    return CastInfo(cast_info.services, cast_info.uuid, cast_info.model_name, cast_info.friendly_name, cast_info.host, cast_info.port, cast_type, manufacturer)
+    return CastInfo(
+        cast_info.services,
+        cast_info.uuid,
+        cast_info.model_name,
+        cast_info.friendly_name,
+        cast_info.host,
+        cast_info.port,
+        cast_type,
+        manufacturer,
+    )
+
 
 def get_device_info(  # pylint: disable=too-many-locals
     host, zconf=None, timeout=30, context=None

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -9,7 +9,12 @@ from uuid import UUID
 
 import zeroconf
 
-from .const import CAST_TYPE_AUDIO, CAST_TYPE_GROUP, SERVICE_TYPE_HOST, SERVICE_TYPE_MDNS
+from .const import (
+    CAST_TYPE_AUDIO,
+    CAST_TYPE_GROUP,
+    SERVICE_TYPE_HOST,
+    SERVICE_TYPE_MDNS,
+)
 from .dial import get_device_info, get_multizone_status, get_ssl_context
 from .models import CastInfo, ServiceInfo
 
@@ -199,14 +204,28 @@ class ZeroConfListener:
             manufacturer = "Google Inc." if service.port != 8009 else None
             if uuid not in self._devices:
                 self._devices[uuid] = CastInfo(
-                    {service_info}, uuid, model_name, friendly_name, host, service.port, cast_type, manufacturer,
+                    {service_info},
+                    uuid,
+                    model_name,
+                    friendly_name,
+                    host,
+                    service.port,
+                    cast_type,
+                    manufacturer,
                 )
             else:
                 # Update stored information
                 services = self._devices[uuid].services
                 services.add(service_info)
                 self._devices[uuid] = CastInfo(
-                    services, uuid, model_name, friendly_name, host, service.port, cast_type, manufacturer
+                    services,
+                    uuid,
+                    model_name,
+                    friendly_name,
+                    host,
+                    service.port,
+                    cast_type,
+                    manufacturer,
                 )
 
         callback(uuid, name)
@@ -353,7 +372,7 @@ class HostBrowser(threading.Thread):
                             "Google Cast Group",
                             group.uuid,
                             CAST_TYPE_GROUP,
-                            "Google Inc."
+                            "Google Inc.",
                         )
                     )
                     uuids.append(group.uuid)
@@ -365,9 +384,23 @@ class HostBrowser(threading.Thread):
 
         # Lock because the ZeroConfListener may also add or remove items
         with self._services_lock:
-            for (port, friendly_name, model_name, uuid, cast_type, manufacturer) in devices:
+            for (
+                port,
+                friendly_name,
+                model_name,
+                uuid,
+                cast_type,
+                manufacturer,
+            ) in devices:
                 self._add_host_service(
-                    host, port, friendly_name, model_name, uuid, callbacks, cast_type, manufacturer
+                    host,
+                    port,
+                    friendly_name,
+                    model_name,
+                    uuid,
+                    callbacks,
+                    cast_type,
+                    manufacturer,
                 )
 
             for uuid in self._devices:
@@ -383,7 +416,17 @@ class HostBrowser(threading.Thread):
         for callback in callbacks:
             callback()
 
-    def _add_host_service(self, host, port, friendly_name, model_name, uuid, callbacks, cast_type, manufacturer):
+    def _add_host_service(
+        self,
+        host,
+        port,
+        friendly_name,
+        model_name,
+        uuid,
+        callbacks,
+        cast_type,
+        manufacturer,
+    ):
         service_info = ServiceInfo(SERVICE_TYPE_HOST, (host, port))
 
         callback = self._cast_listener.add_cast
@@ -400,14 +443,28 @@ class HostBrowser(threading.Thread):
 
         if uuid not in self._devices:
             self._devices[uuid] = CastInfo(
-                {service_info}, uuid, model_name, friendly_name, host, port, cast_type, manufacturer
+                {service_info},
+                uuid,
+                model_name,
+                friendly_name,
+                host,
+                port,
+                cast_type,
+                manufacturer,
             )
         else:
             # Update stored information
             services = self._devices[uuid].services
             services.add(service_info)
             self._devices[uuid] = CastInfo(
-                services, uuid, model_name, friendly_name, host, port, cast_type, manufacturer
+                services,
+                uuid,
+                model_name,
+                friendly_name,
+                host,
+                port,
+                cast_type,
+                manufacturer,
             )
 
         name = f"{host}:{port}"

--- a/pychromecast/models.py
+++ b/pychromecast/models.py
@@ -1,0 +1,19 @@
+"""
+Chromecast types
+"""
+from collections import namedtuple
+
+CastInfo = namedtuple(
+    "CastInfo",
+    [
+        "services",
+        "uuid",
+        "model_name",
+        "friendly_name",
+        "host",
+        "port",
+        "cast_type",
+        "manufacturer",
+    ],
+)
+ServiceInfo = namedtuple("ServiceInfo", ["type", "data"])

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -24,7 +24,7 @@ from . import cast_channel_pb2
 from .controllers import BaseController
 from .controllers.media import MediaController
 from .controllers.receiver import ReceiverController
-from .const import CAST_TYPE_CHROMECAST, MESSAGE_TYPE, REQUEST_ID, SESSION_ID
+from .const import MESSAGE_TYPE, REQUEST_ID, SESSION_ID
 from .dial import get_host_from_service
 from .error import (
     ChromecastConnectionError,

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -171,12 +171,13 @@ class SocketClient(threading.Thread):
     # pylint: disable-next=too-many-arguments
     def __init__(
         self,
-        cast_type=CAST_TYPE_CHROMECAST,
-        tries=None,
-        timeout=None,
-        retry_wait=None,
-        services=None,
-        zconf=None,
+        *,
+        cast_type,
+        tries,
+        timeout,
+        retry_wait,
+        services,
+        zconf,
     ):
         super().__init__()
 

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -169,7 +169,15 @@ class SocketClient(threading.Thread):
     """
 
     # pylint: disable-next=too-many-arguments
-    def __init__(self, cast_type=CAST_TYPE_CHROMECAST, tries=None, timeout=None, retry_wait=None, services=None, zconf=None):
+    def __init__(
+        self,
+        cast_type=CAST_TYPE_CHROMECAST,
+        tries=None,
+        timeout=None,
+        retry_wait=None,
+        services=None,
+        zconf=None,
+    ):
         super().__init__()
 
         self.daemon = True
@@ -290,9 +298,7 @@ class SocketClient(threading.Thread):
                     if host and port:
                         if service_info:
                             try:
-                                self.fn = service_info.properties[b"fn"].decode(
-                                    "utf-8"
-                                )
+                                self.fn = service_info.properties[b"fn"].decode("utf-8")
                             except (AttributeError, KeyError, UnicodeError):
                                 pass
                         self.logger.debug(


### PR DESCRIPTION
### Breaking change
This is a breaking change if `Chromecast` objects are instantiated manually instead of via one of the discovery helpers

Refactor handling of discovered casts and device info
- Simplify code paths by treating casts identified directly by a host:port pair same as auto discovered casts
- Only poll casts via HTTP for device info once when creating `Chromecast` objects

See helper `get_chromecast_from_host` for how to instantiate a `Chromecast` object identified directly by a host:port pair