### PR TITLE
HA Lovelace controller: Prevent sending connect message twice

### DIFF
--- a/pychromecast/controllers/homeassistant.py
+++ b/pychromecast/controllers/homeassistant.py
@@ -74,7 +74,8 @@ class HomeAssistantController(BaseController):
     def connect_hass(self, callback_function=None):
         """Connect to Home Assistant."""
         if self.hass_connected:
-            callback_function()
+            if callback_function:
+                callback_function()
             return
 
         self._on_connect.append(callback_function)

--- a/pychromecast/controllers/homeassistant.py
+++ b/pychromecast/controllers/homeassistant.py
@@ -31,7 +31,7 @@ class HomeAssistantController(BaseController):
         #   urlPath?: string | null;
         # }
         self.status = None
-        self.connecting = False
+        self._connecting = False
         self._on_connect = []
 
     @property
@@ -51,7 +51,7 @@ class HomeAssistantController(BaseController):
     def channel_disconnected(self):
         """Called when a channel is disconnected."""
         self.status = None
-        self.connecting = False
+        self._connecting = False
 
     def receive_message(self, _message, data: dict):
         """Called when a message is received."""
@@ -63,7 +63,7 @@ class HomeAssistantController(BaseController):
                 return True
 
             # We just got connected, call the callbacks.
-            self.connecting = False
+            self._connecting = False
             while self._on_connect:
                 self._on_connect.pop()()
 
@@ -71,19 +71,14 @@ class HomeAssistantController(BaseController):
 
         return False
 
-    def connect_hass(self, callback_function=None):
+    def _connect_hass(self, callback_function=None):
         """Connect to Home Assistant."""
-        if self.hass_connected:
-            if callback_function:
-                callback_function()
-            return
-
         self._on_connect.append(callback_function)
 
-        if self.connecting:
+        if self._connecting:
             return
 
-        self.connecting = True
+        self._connecting = True
         self.send_message(
             {
                 "type": "connect",
@@ -99,23 +94,23 @@ class HomeAssistantController(BaseController):
 
     def get_status(self, callback_function=None):
         """Get status of Home Assistant Cast."""
-        self.send_connected_message(
+        self._send_connected_message(
             {"type": "get_status"}, callback_function=callback_function
         )
 
     def show_lovelace_view(self, view_path, url_path=None, callback_function=None):
         """Show a Lovelace UI."""
-        self.send_connected_message(
+        self._send_connected_message(
             {"type": "show_lovelace_view", "viewPath": view_path, "urlPath": url_path},
             callback_function=callback_function,
         )
 
-    def send_connected_message(self, data, callback_function=None):
+    def _send_connected_message(self, data, callback_function=None):
         """Send a message to a connected Home Assistant Cast"""
         if self.hass_connected:
             self.send_message_nocheck(data, callback_function=callback_function)
             return
 
-        self.connect_hass(
+        self._connect_hass(
             lambda: self.send_message_nocheck(data, callback_function=callback_function)
         )

--- a/pychromecast/controllers/homeassistant.py
+++ b/pychromecast/controllers/homeassistant.py
@@ -79,14 +79,18 @@ class HomeAssistantController(BaseController):
             return
 
         self._connecting = True
-        self.send_message(
-            {
-                "type": "connect",
-                "refreshToken": self.refresh_token,
-                "clientId": self.client_id,
-                "hassUrl": self.hass_url,
-            }
-        )
+        try:
+            self.send_message(
+                {
+                    "type": "connect",
+                    "refreshToken": self.refresh_token,
+                    "clientId": self.client_id,
+                    "hassUrl": self.hass_url,
+                }
+            )
+        except Exception:  # pylint: disable=broad-except
+            self._connecting = False
+            raise
 
     def show_demo(self):
         """Show the demo."""

--- a/pychromecast/controllers/homeassistant.py
+++ b/pychromecast/controllers/homeassistant.py
@@ -96,7 +96,7 @@ class HomeAssistantController(BaseController):
             self._hass_connecting_event.set()
             raise
 
-        self._hass_connecting_event.wait(1)
+        self._hass_connecting_event.wait(10)
         try:
             if not self._hass_connecting_event.is_set():
                 raise PyChromecastError()


### PR DESCRIPTION
We would send a connect message twice, causing the app to lose its connection when creating a new one, and commands to fail.

When you request the view to show, it sends a connect message, then the app starts, it requests a status and sends another connect message, because we are not connected yet