### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,12 +154,14 @@ to the IGNORE\_CEC list in PyChromecast like in the example below.
     pychromecast.IGNORE_CEC.append('*')  # Ignore CEC on all devices
     pychromecast.IGNORE_CEC.append('Living Room')  # Ignore CEC on Chromecasts named Living Room
 
-Firewall Rules
+Networking requirements
 -----------------
-MDNS discovery takes place on port UDP 5353.
-SSDP discovery takes place on port UDP 1900.
+Pychromecast relies on mDNS to discover cast devices. The mDNS protocol relies on multicast UDP on port 5353 which comes with several implications for discovery to work:
+- Multicast UDP must be forwarded by WiFI routers; some WiFi routers are known to drop multicast UDP traffic.
+- The device running pychromecast must allow both inbound and outbound traffic on port 5353.
+- The device running pychromecast must be on the same subnet as the cast devices because mDNS packets are not routed across subnets.
 
-You may want\need to create a firewall rule that allows both of these ports both inbound and outbound. Device discovery may not function properly until this rule is in place.
+If not all of these conditions are met, discovery will not work. In cases where these conditions are impossible to meet, it's possible to pass a list of known IP-addresses or host names to the discovery functions.
 
 Thanks
 ------

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,16 @@ How to use
     >> [cc.device.friendly_name for cc in chromecasts]
     ['Living Room']
 
+    >> # Discover and connect to more than one device
+    >> chromecasts, browser = pychromecast.get_listed_chromecasts(friendly_names=["Living Room","Bed Room","Kitchen"])
+    >> [cc.device.friendly_name for cc in chromecasts]
+    ["Living Room","Bed Room","Kitchen"]
+    
+    >> # If you are seeing less devices get discovered than expected add the below parameter. You can lessen or extend the timeout as needed.
+    >> chromecasts, browser = pychromecast.get_listed_chromecasts(friendly_names=["Living Room","Bed Room","Kitchen"],discovery_timeout=30)
+    >> [cc.device.friendly_name for cc in chromecasts]
+    ["Living Room","Bed Room","Kitchen"]
+
     >> cast = chromecasts[0]
     >> # Start worker thread and wait for cast device to be ready
     >> cast.wait()
@@ -143,6 +153,13 @@ to the IGNORE\_CEC list in PyChromecast like in the example below.
 
     pychromecast.IGNORE_CEC.append('*')  # Ignore CEC on all devices
     pychromecast.IGNORE_CEC.append('Living Room')  # Ignore CEC on Chromecasts named Living Room
+
+Firewall Rules
+-----------------
+MDNS discovery takes place on port UDP 5353.
+SSDP discovery takes place on port UDP 1900.
+
+You may want\need to create a firewall rule that allows both of these ports both inbound and outbound. Device discovery may not function properly until this rule is in place.
 
 Thanks
 ------


### PR DESCRIPTION
So I had some pretty big blockers using the new library and discovery methods. I also finally realized what kind of firewall rules need to be created in order for zeroconf discovery to work properly. On windows I created two rules. one inbound, one outbound, for ports 1900,5353 and allowed them through the firewall. Afterwards I was able to do proper chromecast discovery without needing to disable my firewall. I also added some additional examples on how to discover numerous devices by friendly name, and I think a super important thing to include is the param discovery_timeout. I was getting many more devices using get_chromecasts() that I was not getting with get_listed_chromecasts() so I examined the difference and realized the timing is much more aggressive by default on get_listed_chromecasts(), the param helps alleviate that, and accounts for networks\devices that are slower to respond.