### PR TITLE
Update dial.py

### DIFF
--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -138,7 +138,7 @@ def get_cast_type(cast_info, zconf=None, timeout=30, context=None):
             _LOGGER.debug("cast type: %s, manufacturer: %s", cast_type, manufacturer)
 
         except (urllib.error.HTTPError, urllib.error.URLError, OSError, ValueError):
-            _LOGGER.warning("Failed to determine cast type")
+            _LOGGER.debug("Failed to determine cast type")
             cast_type = CAST_TYPE_CHROMECAST
 
     return CastInfo(


### PR DESCRIPTION
cast type errors from zeroconf, for starters, arent very verbose so printing warnings for them doesnt really add anything except more messages in the client. I would propose relegating these over to the debug channel instead of the warning channel so they dont show up in the console anymore. The errors are handled, and the cast type is overridden anyway and set to CAST_TYPE_CHROMECAST, so it seems kind of silly to warn on these errors. 

At a minimum it would be nice if the error text was included in the warning log so that the user has some type of idea what is going on and how they can potentially fix the problem. I am not even really personally clear on what the problem is I didnt bother to log the actual error, instead I just cut it over to debug channel and let it be.