### PR TITLE
Refactor media controllers

### DIFF
--- a/pychromecast/controllers/bbciplayer.py
+++ b/pychromecast/controllers/bbciplayer.py
@@ -9,38 +9,33 @@ Controller to interface with BBC iPlayer.
 
 import logging
 
-from . import BaseController
+from .media import STREAM_TYPE_BUFFERED, STREAM_TYPE_LIVE, BaseMediaPlayer
 from ..config import APP_BBCIPLAYER
-from .media import STREAM_TYPE_BUFFERED, STREAM_TYPE_LIVE
 
 APP_NAMESPACE = "urn:x-cast:com.google.cast.media"
 
 
-class BbcIplayerController(BaseController):
+class BbcIplayerController(BaseMediaPlayer):
     """Controller to interact with BBC iPlayer namespace."""
 
     def __init__(self):
-        super().__init__(APP_NAMESPACE, APP_BBCIPLAYER)
-
+        super().__init__(APP_BBCIPLAYER)
         self.logger = logging.getLogger(__name__)
 
-    def play_media(self, media_id, is_live=False, **kwargs):
-        """Play BBC iPlayer media"""
+    # pylint: disable-next=arguments-differ
+    def quick_play(self, media_id=None, is_live=False, metadata=None, **kwargs):
+        """Quick Play helper for BBC iPlayer media."""
         stream_type = STREAM_TYPE_LIVE if is_live else STREAM_TYPE_BUFFERED
-        metadata = kwargs.get("metadata", {"metadataType": 0, "title": ""})
+        metadata_default = {"metadataType": 0, "title": ""}
+        if metadata is None:
+            metadata = metadata_default
         subtitle = metadata.pop("subtitle", "")
 
-        msg = {
-            "media": {
-                "contentId": media_id,
-                "customData": {"secondary_title": subtitle},
-                "metadata": metadata,
-                "streamType": stream_type,
-            },
-            "type": "LOAD",
-        }
-        self.send_message(msg, inc_session_id=False)
-
-    def quick_play(self, media_id=None, is_live=False, **kwargs):
-        """Quick Play"""
-        self.play_media(media_id, is_live=is_live, **kwargs)
+        super().quick_play(
+            media_id,
+            None,
+            stream_type=stream_type,
+            metadata=metadata,
+            media_info={"customData": {"secondary_title": subtitle}},
+            **kwargs,
+        )

--- a/pychromecast/controllers/bbcsounds.py
+++ b/pychromecast/controllers/bbcsounds.py
@@ -6,37 +6,30 @@ Controller to interface with BBC Sounds.
 
 import logging
 
-from . import BaseController
+from .media import STREAM_TYPE_BUFFERED, STREAM_TYPE_LIVE, BaseMediaPlayer
 from ..config import APP_BBCSOUNDS
-from .media import STREAM_TYPE_BUFFERED, STREAM_TYPE_LIVE
 
 APP_NAMESPACE = "urn:x-cast:com.google.cast.media"
 
 
-class BbcSoundsController(BaseController):
+class BbcSoundsController(BaseMediaPlayer):
     """Controller to interact with BBC Sounds namespace."""
 
     def __init__(self):
-        super().__init__(APP_NAMESPACE, APP_BBCSOUNDS)
-
+        super().__init__(APP_BBCSOUNDS)
         self.logger = logging.getLogger(__name__)
 
-    def play_media(self, media_id, is_live=False, **kwargs):
-        """Play BBC Sounds media"""
+    # pylint: disable-next=arguments-differ
+    def quick_play(self, media_id=None, is_live=False, metadata=None, **kwargs):
+        """Quick Play helper for BBC Sounds media"""
         stream_type = STREAM_TYPE_LIVE if is_live else STREAM_TYPE_BUFFERED
         metadata_default = {"metadataType": 0, "title": ""}
-
-        msg = {
-            "media": {
-                "contentId": media_id,
-                "metadata": kwargs.get("metadata", metadata_default),
-                "streamType": stream_type,
-            },
-            "type": "LOAD",
-        }
-
-        self.send_message(msg, inc_session_id=False)
-
-    def quick_play(self, media_id=None, is_live=False, **kwargs):
-        """Quick Play"""
-        self.play_media(media_id, is_live=is_live, **kwargs)
+        if metadata is None:
+            metadata = metadata_default
+        super().quick_play(
+            media_id,
+            None,
+            stream_type=stream_type,
+            metadata=metadata,
+            **kwargs,
+        )

--- a/pychromecast/controllers/bubbleupnp.py
+++ b/pychromecast/controllers/bubbleupnp.py
@@ -3,17 +3,11 @@ Simple Controller to use BubbleUPNP as a media controller.
 """
 
 from ..config import APP_BUBBLEUPNP
-from .media import MediaController
+from .media import BaseMediaPlayer
 
 
-class BubbleUPNPController(MediaController):
+class BubbleUPNPController(BaseMediaPlayer):
     """Controller to interact with BubbleUPNP app namespace."""
 
     def __init__(self):
-        super().__init__()
-        self.app_id = APP_BUBBLEUPNP
-        self.supporting_app_id = APP_BUBBLEUPNP
-
-    def quick_play(self, media_id=None, media_type="video/mp4", **kwargs):
-        """Quick Play"""
-        self.play_media(media_id, media_type, **kwargs)
+        super().__init__(supporting_app_id=APP_BUBBLEUPNP)

--- a/pychromecast/controllers/homeassistant_media.py
+++ b/pychromecast/controllers/homeassistant_media.py
@@ -3,17 +3,11 @@ Simple Controller to use the Home Assistant Media Player Cast App as a media con
 """
 
 from ..config import APP_HOMEASSISTANT_MEDIA
-from .media import MediaController
+from .media import BaseMediaPlayer
 
 
-class HomeAssistantMediaController(MediaController):
+class HomeAssistantMediaController(BaseMediaPlayer):
     """Controller to interact with HomeAssistantMedia app namespace."""
 
     def __init__(self):
-        super().__init__()
-        self.app_id = APP_HOMEASSISTANT_MEDIA
-        self.supporting_app_id = APP_HOMEASSISTANT_MEDIA
-
-    def quick_play(self, media_id=None, media_type="video/mp4", **kwargs):
-        """Quick Play"""
-        self.play_media(media_id, media_type, **kwargs)
+        super().__init__(supporting_app_id=APP_HOMEASSISTANT_MEDIA)

--- a/pychromecast/quick_play.py
+++ b/pychromecast/quick_play.py
@@ -4,7 +4,7 @@ from .controllers.bbciplayer import BbcIplayerController
 from .controllers.bbcsounds import BbcSoundsController
 from .controllers.bubbleupnp import BubbleUPNPController
 from .controllers.homeassistant_media import HomeAssistantMediaController
-from .controllers.media import MediaController
+from .controllers.media import DefaultMediaReceiverController
 from .controllers.supla import SuplaController
 from .controllers.yleareena import YleAreenaController
 from .controllers.youtube import YouTubeController
@@ -53,22 +53,22 @@ def quick_play(cast, app_name, data):
             "BUFFERED" or "LIVE"
     """
 
-    if app_name == "youtube":
-        controller = YouTubeController()
+    if app_name == "bbciplayer":
+        controller = BbcIplayerController()
+    elif app_name == "bbcsounds":
+        controller = BbcSoundsController()
+    elif app_name == "bubbleupnp":
+        controller = BubbleUPNPController()
+    elif app_name == "default_media_receiver":
+        controller = DefaultMediaReceiverController()
+    elif app_name == "homeassistant_media":
+        controller = HomeAssistantMediaController()
     elif app_name == "supla":
         controller = SuplaController()
     elif app_name == "yleareena":
         controller = YleAreenaController()
-    elif app_name == "bubbleupnp":
-        controller = BubbleUPNPController()
-    elif app_name == "bbciplayer":
-        controller = BbcIplayerController()
-    elif app_name == "bbcsounds":
-        controller = BbcSoundsController()
-    elif app_name == "homeassistant_media":
-        controller = HomeAssistantMediaController()
-    elif app_name == "default_media_receiver":
-        controller = MediaController()
+    elif app_name == "youtube":
+        controller = YouTubeController()
     else:
         raise NotImplementedError()
 

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -904,12 +904,15 @@ class SocketClient(threading.Thread):
             raise PyChromecastStopped("Socket client's thread is stopped.")
         if not self.connecting and not self._force_recon:
             try:
-                if not no_add_request_id and callback_function:
-                    self._request_callbacks[request_id] = {
-                        "event": threading.Event(),
-                        "response": None,
-                        "function": callback_function,
-                    }
+                if callback_function:
+                    if not no_add_request_id:
+                        self._request_callbacks[request_id] = {
+                            "event": threading.Event(),
+                            "response": None,
+                            "function": callback_function,
+                        }
+                    else:
+                        callback_function(None)
                 self.socket.sendall(be_size + msg.SerializeToString())
             except socket.error:
                 self._request_callbacks.pop(request_id, None)
@@ -924,7 +927,12 @@ class SocketClient(threading.Thread):
             raise NotConnected(f"Chromecast {self.host}:{self.port} is connecting...")
 
     def send_platform_message(
-        self, namespace, message, inc_session_id=False, callback_function_param=False
+        self,
+        namespace,
+        message,
+        inc_session_id=False,
+        callback_function_param=False,
+        no_add_request_id=False,
     ):
         """Helper method to send a message to the platform."""
         return self.send_message(
@@ -933,10 +941,16 @@ class SocketClient(threading.Thread):
             message,
             inc_session_id,
             callback_function_param,
+            no_add_request_id=no_add_request_id,
         )
 
     def send_app_message(
-        self, namespace, message, inc_session_id=False, callback_function_param=False
+        self,
+        namespace,
+        message,
+        inc_session_id=False,
+        callback_function_param=False,
+        no_add_request_id=False,
     ):
         """Helper method to send a message to current running app."""
         if namespace not in self.app_namespaces:
@@ -951,6 +965,7 @@ class SocketClient(threading.Thread):
             message,
             inc_session_id,
             callback_function_param,
+            no_add_request_id=no_add_request_id,
         )
 
     def register_connection_listener(self, listener: ConnectionStatusListener):


### PR DESCRIPTION
Refactor media controllers to make it easier to implement support for customized media player apps which load media via the standard namespace `urn:x-cast:com.google.cast.media`.