### PR TITLE
dial: Don't attempt resolve if zeroconf loop isn't running

### DIFF
--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -35,7 +35,10 @@ def get_host_from_service(service, zconf):
         return service.data + (None,)
 
     try:
-        service_info = zconf.get_service_info("_googlecast._tcp.local.", service.data)
+        if zconf.loop.is_running():
+            service_info = zconf.get_service_info(
+                "_googlecast._tcp.local.", service.data
+            )
         if service_info:
             _LOGGER.debug(
                 "get_info_from_service resolved service %s to service_info %s",


### PR DESCRIPTION
zeroconf asserts that the loop is running, so if we call this function
without the loop running, it will hit the assert.

Closes #641.