### PR TITLE
Revert "pin to protobuf v3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-protobuf>=3.19.1,<4
+protobuf>=3.19.1
 zeroconf>=0.25.1
 casttube>=0.2.0


### PR DESCRIPTION
Reverts home-assistant-libs/pychromecast#625

Restricting protobuf to version 3 prevents migrating Home Assistant to protobuf 4.x.
According to Google documentation, protobuf 3.19 is forward compatible with version 4.x, so we try to drop this restriction again