### PR TITLE
Fix error with select when python process exceeds 1024 open file descriptors

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -565,7 +565,8 @@ class SocketClient(threading.Thread):
 
         # poll the socket, as well as the socketpair to allow us to be interrupted
         rlist = [self.socket, self.socketpair[0]]
-        # Map file descriptors to socket objects
+        # Map file descriptors to socket objects because select.select does not support fd > 1024
+        # https://stackoverflow.com/questions/14250751/how-to-increase-filedescriptors-range-in-python-select
         fd_to_socket = {rlist_item.fileno(): rlist_item for rlist_item in rlist}
         try:
             poll_obj = select.poll()

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -564,28 +564,22 @@ class SocketClient(threading.Thread):
 
         # poll the socket, as well as the socketpair to allow us to be interrupted
         rlist = [self.socket, self.socketpair[0]]
+        # Map file descriptors to socket objects
+        fd_to_socket = { rlist_item.fileno(): rlist_item for rlist_item in rlist }
         try:
-            can_read, _, _ = select.select(rlist, [], [], timeout)
+            #can_read, _, _ = select.select(rlist, [], [], timeout)
             poll_obj = select.poll()
             for poll_fd in rlist:
                 poll_obj.register(poll_fd, select.POLLIN)
             poll_result = poll_obj.poll(timeout)
+            can_read = [fd_to_socket[fd] for fd, _status in poll_result]
             #self.logger.debug(
-            #    "[%s(%s):%s] run_once poll_result: %s",
+            #    "[%s(%s):%s] run_once can_read: %s",
             #    self.fn or "",
             #    self.host,
             #    self.port,
-            #    poll_result,
+            #    can_read,
             #)
-            can_read2 = [fd for fd, _status in poll_result]
-            self.logger.debug(
-                "[%s(%s):%s] run_once can_read: %s ; can_read2: %s",
-                self.fn or "",
-                self.host,
-                self.port,
-                can_read,
-                can_read2,
-            )
         except (ValueError, OSError) as exc:
             self.logger.error(
                 "[%s(%s):%s] Error in select call: %s",

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -64,6 +64,7 @@ POLL_TIME_NON_BLOCKING = 0.01
 TIMEOUT_TIME = 30
 RETRY_TIME = 5
 
+
 class InterruptLoop(Exception):
     """The chromecast has been manually stopped."""
 
@@ -565,7 +566,7 @@ class SocketClient(threading.Thread):
         # poll the socket, as well as the socketpair to allow us to be interrupted
         rlist = [self.socket, self.socketpair[0]]
         # Map file descriptors to socket objects
-        fd_to_socket = { rlist_item.fileno(): rlist_item for rlist_item in rlist }
+        fd_to_socket = {rlist_item.fileno(): rlist_item for rlist_item in rlist}
         try:
             poll_obj = select.poll()
             for poll_fd in rlist:

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -63,7 +63,6 @@ POLL_TIME_BLOCKING = 5.0
 POLL_TIME_NON_BLOCKING = 0.01
 TIMEOUT_TIME = 30
 RETRY_TIME = 5
-READ_ONLY = select.POLLIN | select.POLLPRI | select.POLLHUP | select.POLLERR
 
 class InterruptLoop(Exception):
     """The chromecast has been manually stopped."""
@@ -566,8 +565,8 @@ class SocketClient(threading.Thread):
         # poll the socket, as well as the socketpair to allow us to be interrupted
         try:
             poll = select.poll()
-            poll.register(self.socket, READ_ONLY)
-            poll.register(self.socketpair[0], READ_ONLY)
+            for poll_fd in (self.socket, self.socketpair[0]):
+                poll.register(poll_fd, select.POLLIN | select.POLLPRI | select.POLLHUP | select.POLLERR)
             poll_result = poll.poll(timeout)
             can_read = [fd for fd, _status in poll_result]
         except (ValueError, OSError) as exc:

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -556,6 +556,13 @@ class SocketClient(threading.Thread):
         receive something on the socket (get_socket()).
         """
         # pylint: disable=too-many-branches, too-many-return-statements
+        self.logger.debug(
+            "[%s(%s):%s] run_once timeout: %s",
+            self.fn or "",
+            self.host,
+            self.port,
+            timeout,
+        )
 
         try:
             if not self._check_connection():

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -567,19 +567,11 @@ class SocketClient(threading.Thread):
         # Map file descriptors to socket objects
         fd_to_socket = { rlist_item.fileno(): rlist_item for rlist_item in rlist }
         try:
-            #can_read, _, _ = select.select(rlist, [], [], timeout)
             poll_obj = select.poll()
             for poll_fd in rlist:
                 poll_obj.register(poll_fd, select.POLLIN)
             poll_result = poll_obj.poll(timeout)
             can_read = [fd_to_socket[fd] for fd, _status in poll_result]
-            #self.logger.debug(
-            #    "[%s(%s):%s] run_once can_read: %s",
-            #    self.fn or "",
-            #    self.host,
-            #    self.port,
-            #    can_read,
-            #)
         except (ValueError, OSError) as exc:
             self.logger.error(
                 "[%s(%s):%s] Error in select call: %s",

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -571,9 +571,14 @@ class SocketClient(threading.Thread):
             return 1
 
         # poll the socket, as well as the socketpair to allow us to be interrupted
-        rlist = [self.socket, self.socketpair[0]]
+        #rlist = [self.socket, self.socketpair[0]]
+        #try:
+        #    can_read, _, _ = select.select(rlist, [], [], timeout)
         try:
-            can_read, _, _ = select.select(rlist, [], [], timeout)
+            poll = select.poll()
+            poll.register(self.socket, POLLIN)
+            poll.register(self.socketpair[0], POLLIN)
+            poll.poll(timeout)
         except (ValueError, OSError) as exc:
             self.logger.error(
                 "[%s(%s):%s] Error in select call: %s",

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -568,7 +568,8 @@ class SocketClient(threading.Thread):
             poll = select.poll()
             poll.register(self.socket, READ_ONLY)
             poll.register(self.socketpair[0], READ_ONLY)
-            poll.poll(timeout)
+            poll_result = poll.poll(timeout)
+            can_read = [fd for fd, _status in poll_result]
         except (ValueError, OSError) as exc:
             self.logger.error(
                 "[%s(%s):%s] Error in select call: %s",

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -568,21 +568,21 @@ class SocketClient(threading.Thread):
             for poll_fd in (self.socket, self.socketpair[0]):
                 poll_obj.register(poll_fd, select.POLLIN)
             poll_result = poll_obj.poll(timeout)
-            self.logger.debug(
-                "[%s(%s):%s] run_once poll_result: %s",
-                self.fn or "",
-                self.host,
-                self.port,
-                poll_result,
-            )
+            #self.logger.debug(
+            #    "[%s(%s):%s] run_once poll_result: %s",
+            #    self.fn or "",
+            #    self.host,
+            #    self.port,
+            #    poll_result,
+            #)
             can_read = [fd for fd, _status in poll_result]
-            self.logger.debug(
-                "[%s(%s):%s] run_once can_read: %s",
-                self.fn or "",
-                self.host,
-                self.port,
-                can_read,
-            )
+            #self.logger.debug(
+            #    "[%s(%s):%s] run_once can_read: %s",
+            #    self.fn or "",
+            #    self.host,
+            #    self.port,
+            #    can_read,
+            #)
         except (ValueError, OSError) as exc:
             self.logger.error(
                 "[%s(%s):%s] Error in select call: %s",

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -564,11 +564,25 @@ class SocketClient(threading.Thread):
 
         # poll the socket, as well as the socketpair to allow us to be interrupted
         try:
-            poll = select.poll()
+            poll_obj = select.poll()
             for poll_fd in (self.socket, self.socketpair[0]):
-                poll.register(poll_fd, select.POLLIN | select.POLLPRI | select.POLLHUP | select.POLLERR)
-            poll_result = poll.poll(timeout)
+                poll_obj.register(poll_fd, select.POLLIN)
+            poll_result = poll_obj.poll(timeout)
+            self.logger.debug(
+                "[%s(%s):%s] run_once poll_result: %s",
+                self.fn or "",
+                self.host,
+                self.port,
+                poll_result,
+            )
             can_read = [fd for fd, _status in poll_result]
+            self.logger.debug(
+                "[%s(%s):%s] run_once can_read: %s",
+                self.fn or "",
+                self.host,
+                self.port,
+                can_read,
+            )
         except (ValueError, OSError) as exc:
             self.logger.error(
                 "[%s(%s):%s] Error in select call: %s",


### PR DESCRIPTION
When the python process has over 1024 open file descriptors, the select.select() function will throw an error.
Error in select call: filedescriptor out of range in select()

Replace select.select with select.poll to avoid this error.

https://github.com/home-assistant/core/issues/79519