### PR TITLE
Adding support for reported unknown devices

### DIFF
--- a/pychromecast/const.py
+++ b/pychromecast/const.py
@@ -9,6 +9,16 @@ CAST_TYPE_AUDIO = "audio"
 CAST_TYPE_GROUP = "group"
 
 MF_GOOGLE = "Google Inc."
+MF_LENOVO = "LENOVO"
+MF_LG = "LG"
+MF_MARSHALL = "Marshall"
+MF_NVIDIA = "NVIDIA"
+MF_PHILIPS = "Philips"
+MF_PIONEER = "Pioneer"
+MF_SONY = "Sony"
+MF_VIZIO = "Vizio"
+MF_WNC = "wnc"
+MF_XIAOMI = "Xiaomi"
 
 CAST_TYPES = {
     "chromecast audio": (CAST_TYPE_AUDIO, MF_GOOGLE),
@@ -17,17 +27,25 @@ CAST_TYPES = {
     "google cast group": (CAST_TYPE_GROUP, MF_GOOGLE),
     "google home mini": (CAST_TYPE_AUDIO, MF_GOOGLE),
     "google home": (CAST_TYPE_AUDIO, MF_GOOGLE),
-    "google nest hub": (CAST_TYPE_CHROMECAST, MF_GOOGLE),
     "google nest hub max": (CAST_TYPE_CHROMECAST, MF_GOOGLE),
+    "google nest hub": (CAST_TYPE_CHROMECAST, MF_GOOGLE),
     "google nest mini": (CAST_TYPE_AUDIO, MF_GOOGLE),
-    "lenovocd-24502f": (CAST_TYPE_AUDIO, "LENOVO"),
-    "mitv-mssp2": (CAST_TYPE_CHROMECAST, "Xiaomi"),
     "nest audio": (CAST_TYPE_AUDIO, MF_GOOGLE),
     "nest wifi point": (CAST_TYPE_AUDIO, MF_GOOGLE),
-    "shield android tv": (CAST_TYPE_CHROMECAST, "NVIDIA"),
-    "bravia 4k vh2": (CAST_TYPE_CHROMECAST, "Sony"),
-    "marshall stanmore ii": (CAST_TYPE_AUDIO, "Unknown manufacturer"),
-    "C4A": (CAST_TYPE_AUDIO, "Sony Corporation"),
+    "bravia 4k vh2": (CAST_TYPE_CHROMECAST, MF_SONY),
+    "C4A": (CAST_TYPE_AUDIO, MF_SONY),
+    "lenovocd-24502f": (CAST_TYPE_AUDIO, MF_LENOVO),
+    "Lenovo Smart Display 7": (CAST_TYPE_CHROMECAST, MF_LENOVO),
+    "LG WK7 ThinQ Speaker": (CAST_TYPE_AUDIO, MF_LG),
+    "marshall stanmore ii": (CAST_TYPE_AUDIO, MF_MARSHALL),
+    "mitv-mssp2": (CAST_TYPE_CHROMECAST, MF_XIAOMI),
+    "Pioneer VSX-831": (CAST_TYPE_AUDIO, MF_PIONEER),
+    "Pioneer VSX-1131": (CAST_TYPE_AUDIO, MF_PIONEER),
+    "Pioneer VSX-LX305": (CAST_TYPE_AUDIO, MF_PIONEER),
+    "shield android tv": (CAST_TYPE_CHROMECAST, MF_NVIDIA),
+    "Stream TV": (CAST_TYPE_CHROMECAST, MF_WNC),
+    "TPM191E": (CAST_TYPE_CHROMECAST, MF_PHILIPS),
+    "V705-H3": (CAST_TYPE_CHROMECAST, MF_VIZIO),
 }
 
 SERVICE_TYPE_HOST = "host"


### PR DESCRIPTION
There are a list of unknown devices in the homassistant/core issues, this PR gives the library the support for those.

It also creates constants for all the manufacturer names