### PR TITLE
Revert "Revert "Fix error with select when python process exceeds 1024 open file descriptors""

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -565,8 +565,15 @@ class SocketClient(threading.Thread):
 
         # poll the socket, as well as the socketpair to allow us to be interrupted
         rlist = [self.socket, self.socketpair[0]]
+        # Map file descriptors to socket objects because select.select does not support fd > 1024
+        # https://stackoverflow.com/questions/14250751/how-to-increase-filedescriptors-range-in-python-select
+        fd_to_socket = {rlist_item.fileno(): rlist_item for rlist_item in rlist}
         try:
-            can_read, _, _ = select.select(rlist, [], [], timeout)
+            poll_obj = select.poll()
+            for poll_fd in rlist:
+                poll_obj.register(poll_fd, select.POLLIN)
+            poll_result = poll_obj.poll(timeout)
+            can_read = [fd_to_socket[fd] for fd, _status in poll_result]
         except (ValueError, OSError) as exc:
             self.logger.error(
                 "[%s(%s):%s] Error in select call: %s",


### PR DESCRIPTION
Apply #676 again, so the implementation can be corrected.