### PR TITLE
Add JBL Link 10, 20, 300, 500

### DIFF
--- a/pychromecast/const.py
+++ b/pychromecast/const.py
@@ -9,6 +9,7 @@ CAST_TYPE_AUDIO = "audio"
 CAST_TYPE_GROUP = "group"
 
 MF_GOOGLE = "Google Inc."
+MF_JBL = "JBL"
 MF_LENOVO = "LENOVO"
 MF_LG = "LG"
 MF_MARSHALL = "Marshall"
@@ -36,6 +37,10 @@ CAST_TYPES = {
     "nest wifi point": (CAST_TYPE_AUDIO, MF_GOOGLE),
     "bravia 4k vh2": (CAST_TYPE_CHROMECAST, MF_SONY),
     "C4A": (CAST_TYPE_AUDIO, MF_SONY),
+    "JBL Link 10": (CAST_TYPE_AUDIO, MF_JBL),
+    "JBL Link 20": (CAST_TYPE_AUDIO, MF_JBL),
+    "JBL Link 300": (CAST_TYPE_AUDIO, MF_JBL),
+    "JBL Link 500": (CAST_TYPE_AUDIO, MF_JBL),
     "lenovocd-24502f": (CAST_TYPE_AUDIO, MF_LENOVO),
     "Lenovo Smart Display 7": (CAST_TYPE_CHROMECAST, MF_LENOVO),
     "LG WK7 ThinQ Speaker": (CAST_TYPE_AUDIO, MF_LG),


### PR DESCRIPTION
Got a log line saying my JBL Link 20 wasn't recognised:

```
2023-01-31 22:44:13.555 INFO (zeroconf-ServiceBrowser-_googlecast._tcp-5684791) [homeassistant.components.cast.helpers] Fetched cast details for unknown model 'JBL Link 20' manufacturer: 'JBL', type: 'audio'. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+cast%22
```

Noticed that JBL wasn't present in the list of manufacturers in `pychromecast`, added my JBL Link 20 alongside its family; the Link 10, 300 and 500.