### PR TITLE
Add SVS Pro SoundBase

### DIFF
--- a/pychromecast/const.py
+++ b/pychromecast/const.py
@@ -16,6 +16,7 @@ MF_NVIDIA = "NVIDIA"
 MF_PHILIPS = "Philips"
 MF_PIONEER = "Pioneer"
 MF_SONY = "Sony"
+MF_SVS = "SVS"
 MF_VIZIO = "Vizio"
 MF_WNC = "wnc"
 MF_XIAOMI = "Xiaomi"
@@ -46,6 +47,7 @@ CAST_TYPES = {
     "Pioneer VSX-LX305": (CAST_TYPE_AUDIO, MF_PIONEER),
     "shield android tv": (CAST_TYPE_CHROMECAST, MF_NVIDIA),
     "Stream TV": (CAST_TYPE_CHROMECAST, MF_WNC),
+    "SVS Pro SoundBase": (CAST_TYPE_AUDIO, MF_SVS),
     "TPM191E": (CAST_TYPE_CHROMECAST, MF_PHILIPS),
     "V705-H3": (CAST_TYPE_CHROMECAST, MF_VIZIO),
 }


### PR DESCRIPTION
Adding this device according to this log message:

```
2023-02-11 20:05:09.619 INFO (zeroconf-ServiceBrowser-_googlecast._tcp-107561) [homeassistant.components.cast.helpers] Fetched cast details for unknown model 'SVS Pro SoundBase' manufacturer: 'SVS', type: 'audio'. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+cast%22
```

Signed-off-by: Felix Kaechele <felix@kaechele.ca>