### PR TITLE
Fix known_hosts for older chromecasts

### DIFF
--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -178,6 +178,7 @@ def get_device_info(  # pylint: disable=too-many-locals
         if services is None:
             services = [ServiceInfo(SERVICE_TYPE_HOST, (host, 8009))]
 
+        # Try connection with SSL first, and if it fails fall back to non-SSL
         try:
             _, status = _get_status(
                 services,

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -204,7 +204,7 @@ def get_device_info(  # pylint: disable=too-many-locals
         manufacturer = "Unknown manufacturer"
         model_name = "Unknown model name"
         multizone_supported = False
-        udn = status.get("ssdp_udn", None)
+        udn = None
 
         if "device_info" in status:
             device_info = status["device_info"]
@@ -216,6 +216,8 @@ def get_device_info(  # pylint: disable=too-many-locals
             model_name = device_info.get("model_name", model_name)
             manufacturer = device_info.get("manufacturer", manufacturer)
             udn = device_info.get("ssdp_udn", None)
+        else:
+            udn = status.get("ssdp_udn", None)
 
         if not display_supported:
             cast_type = CAST_TYPE_AUDIO

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -76,9 +76,11 @@ def _get_status(services, zconf, path, timeout, context, secure=None):
 
     if secure is None:
         try:
-            return _get_status(services, zconf, path, timeout/2, context, secure=True)
+            return _get_status(services, zconf, path, timeout / 2, context, secure=True)
         except (urllib.error.HTTPError, urllib.error.URLError):
-            return _get_status(services, zconf, path, timeout/2, context, secure=False)
+            return _get_status(
+                services, zconf, path, timeout / 2, context, secure=False
+            )
 
     for service in services.copy():
         host, _, _ = get_host_from_service(service, zconf)

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -259,7 +259,7 @@ HOSTLISTENER_MAX_FAIL = 5
 class HostBrowser(threading.Thread):
     """Repeateadly poll a set of known hosts."""
 
-    def __init__(self, cast_listener, devices, lock, timeout=DISCOVER_TIMEOUT):
+    def __init__(self, cast_listener, devices, lock):
         super().__init__(daemon=True)
         self._cast_listener = cast_listener
         self._devices = devices
@@ -268,7 +268,6 @@ class HostBrowser(threading.Thread):
         self._services_lock = lock
         self._start_requested = False
         self._context = None
-        self._timeout = timeout
         self.stop = threading.Event()
 
     def add_hosts(self, known_hosts):
@@ -326,9 +325,7 @@ class HostBrowser(threading.Thread):
                 # This host should not be polled
                 continue
 
-            device_status = get_device_info(
-                host, timeout=self._timeout / len(known_hosts), context=self._context
-            )
+            device_status = get_device_info(host, timeout=30, context=self._context)
 
             if not device_status:
                 hoststatus.failcount += 1
@@ -529,13 +526,7 @@ class CastBrowser:
     instance is passed, a new instance will be created.
     """
 
-    def __init__(
-        self,
-        cast_listener,
-        zeroconf_instance=None,
-        known_hosts=None,
-        timeout=DISCOVER_TIMEOUT,
-    ):
+    def __init__(self, cast_listener, zeroconf_instance=None, known_hosts=None):
         self._cast_listener = cast_listener
         self.zc = zeroconf_instance  # pylint: disable=invalid-name
         self._zc_browser = None
@@ -543,7 +534,7 @@ class CastBrowser:
         self.services = self.devices  # For backwards compatibility
         self._services_lock = threading.Lock()
         self.host_browser = HostBrowser(
-            self._cast_listener, self.devices, self._services_lock, timeout=timeout
+            self._cast_listener, self.devices, self._services_lock
         )
         self.zeroconf_listener = ZeroConfListener(
             self._cast_listener, self.devices, self.host_browser, self._services_lock
@@ -643,9 +634,7 @@ def discover_chromecasts(
 
     discover_complete = threading.Event()
     zconf = zeroconf_instance or zeroconf.Zeroconf()
-    browser = CastBrowser(
-        SimpleCastListener(add_callback), zconf, known_hosts, timeout=timeout
-    )
+    browser = CastBrowser(SimpleCastListener(add_callback), zconf, known_hosts)
     browser.start_discovery()
 
     # Wait for the timeout or the maximum number of devices
@@ -696,9 +685,7 @@ def discover_listed_chromecasts(
     discover_complete = threading.Event()
 
     zconf = zeroconf_instance or zeroconf.Zeroconf()
-    browser = CastBrowser(
-        SimpleCastListener(add_callback), zconf, known_hosts, timeout=discovery_timeout
-    )
+    browser = CastBrowser(SimpleCastListener(add_callback), zconf, known_hosts)
     browser.start_discovery()
 
     # Wait for the timeout or found all wanted devices

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -259,7 +259,7 @@ HOSTLISTENER_MAX_FAIL = 5
 class HostBrowser(threading.Thread):
     """Repeateadly poll a set of known hosts."""
 
-    def __init__(self, cast_listener, devices, lock, timeout):
+    def __init__(self, cast_listener, devices, lock, timeout=DISCOVER_TIMEOUT):
         super().__init__(daemon=True)
         self._cast_listener = cast_listener
         self._devices = devices
@@ -326,7 +326,9 @@ class HostBrowser(threading.Thread):
                 # This host should not be polled
                 continue
 
-            device_status = get_device_info(host, timeout=self._timeout/len(known_hosts), context=self._context)
+            device_status = get_device_info(
+                host, timeout=self._timeout / len(known_hosts), context=self._context
+            )
 
             if not device_status:
                 hoststatus.failcount += 1
@@ -527,7 +529,13 @@ class CastBrowser:
     instance is passed, a new instance will be created.
     """
 
-    def __init__(self, cast_listener, zeroconf_instance=None, known_hosts=None, timeout=DISCOVER_TIMEOUT):
+    def __init__(
+        self,
+        cast_listener,
+        zeroconf_instance=None,
+        known_hosts=None,
+        timeout=DISCOVER_TIMEOUT,
+    ):
         self._cast_listener = cast_listener
         self.zc = zeroconf_instance  # pylint: disable=invalid-name
         self._zc_browser = None
@@ -535,7 +543,7 @@ class CastBrowser:
         self.services = self.devices  # For backwards compatibility
         self._services_lock = threading.Lock()
         self.host_browser = HostBrowser(
-            self._cast_listener, self.devices, self._services_lock, timeout=DISCOVER_TIMEOUT
+            self._cast_listener, self.devices, self._services_lock, timeout=timeout
         )
         self.zeroconf_listener = ZeroConfListener(
             self._cast_listener, self.devices, self.host_browser, self._services_lock
@@ -635,7 +643,9 @@ def discover_chromecasts(
 
     discover_complete = threading.Event()
     zconf = zeroconf_instance or zeroconf.Zeroconf()
-    browser = CastBrowser(SimpleCastListener(add_callback), zconf, known_hosts, timeout=timeout)
+    browser = CastBrowser(
+        SimpleCastListener(add_callback), zconf, known_hosts, timeout=timeout
+    )
     browser.start_discovery()
 
     # Wait for the timeout or the maximum number of devices
@@ -686,7 +696,9 @@ def discover_listed_chromecasts(
     discover_complete = threading.Event()
 
     zconf = zeroconf_instance or zeroconf.Zeroconf()
-    browser = CastBrowser(SimpleCastListener(add_callback), zconf, known_hosts, timeout=discovery_timeout)
+    browser = CastBrowser(
+        SimpleCastListener(add_callback), zconf, known_hosts, timeout=discovery_timeout
+    )
     browser.start_discovery()
 
     # Wait for the timeout or found all wanted devices

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -259,7 +259,7 @@ HOSTLISTENER_MAX_FAIL = 5
 class HostBrowser(threading.Thread):
     """Repeateadly poll a set of known hosts."""
 
-    def __init__(self, cast_listener, devices, lock):
+    def __init__(self, cast_listener, devices, lock, timeout):
         super().__init__(daemon=True)
         self._cast_listener = cast_listener
         self._devices = devices
@@ -268,6 +268,7 @@ class HostBrowser(threading.Thread):
         self._services_lock = lock
         self._start_requested = False
         self._context = None
+        self._timeout = timeout
         self.stop = threading.Event()
 
     def add_hosts(self, known_hosts):
@@ -325,7 +326,7 @@ class HostBrowser(threading.Thread):
                 # This host should not be polled
                 continue
 
-            device_status = get_device_info(host, timeout=30, context=self._context)
+            device_status = get_device_info(host, timeout=self._timeout/len(known_hosts), context=self._context)
 
             if not device_status:
                 hoststatus.failcount += 1
@@ -526,7 +527,7 @@ class CastBrowser:
     instance is passed, a new instance will be created.
     """
 
-    def __init__(self, cast_listener, zeroconf_instance=None, known_hosts=None):
+    def __init__(self, cast_listener, zeroconf_instance=None, known_hosts=None, timeout=DISCOVER_TIMEOUT):
         self._cast_listener = cast_listener
         self.zc = zeroconf_instance  # pylint: disable=invalid-name
         self._zc_browser = None
@@ -534,7 +535,7 @@ class CastBrowser:
         self.services = self.devices  # For backwards compatibility
         self._services_lock = threading.Lock()
         self.host_browser = HostBrowser(
-            self._cast_listener, self.devices, self._services_lock
+            self._cast_listener, self.devices, self._services_lock, timeout=DISCOVER_TIMEOUT
         )
         self.zeroconf_listener = ZeroConfListener(
             self._cast_listener, self.devices, self.host_browser, self._services_lock
@@ -634,7 +635,7 @@ def discover_chromecasts(
 
     discover_complete = threading.Event()
     zconf = zeroconf_instance or zeroconf.Zeroconf()
-    browser = CastBrowser(SimpleCastListener(add_callback), zconf, known_hosts)
+    browser = CastBrowser(SimpleCastListener(add_callback), zconf, known_hosts, timeout=timeout)
     browser.start_discovery()
 
     # Wait for the timeout or the maximum number of devices
@@ -685,7 +686,7 @@ def discover_listed_chromecasts(
     discover_complete = threading.Event()
 
     zconf = zeroconf_instance or zeroconf.Zeroconf()
-    browser = CastBrowser(SimpleCastListener(add_callback), zconf, known_hosts)
+    browser = CastBrowser(SimpleCastListener(add_callback), zconf, known_hosts, timeout=discovery_timeout)
     browser.start_discovery()
 
     # Wait for the timeout or found all wanted devices


### PR DESCRIPTION
Older chromecasts (for example my Nvidia Shield TV) don't support secure `/setup/eureka_info` endpoint. That's why they don't get detected with `known_hosts` option in current implementation. There are several issues related to that (e.g. https://github.com/home-assistant-libs/pychromecast/issues/611)

This PR does the following:
- When `secure=None` in `_get_status` it first tries secure request, if that times out or returns an error, it falls back to insecure. This codepath is only used in `get_device_info`
- In discovery HostBrowser propagates appropriate timeout to `get_device_info`, so there is enough time to try all specified `known_hosts`.