### PR TITLE
Fix deprecated call to ssl.SSLContext without specifying protocol

### DIFF
--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -99,7 +99,7 @@ def _get_status(services, zconf, path, secure, timeout, context):
 
 def get_ssl_context():
     """Create an SSL context."""
-    context = ssl.SSLContext()
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     context.verify_mode = ssl.CERT_NONE
     return context
 


### PR DESCRIPTION
Fixes https://github.com/home-assistant-libs/pychromecast/issues/759