### PR TITLE
Increase homeassistant lovelace connect timeout and make it configurable

### DIFF
--- a/pychromecast/controllers/homeassistant.py
+++ b/pychromecast/controllers/homeassistant.py
@@ -9,6 +9,7 @@ from . import BaseController
 
 
 APP_NAMESPACE = "urn:x-cast:com.nabucasa.hast"
+DEFAULT_HASS_CONNECT_TIMEOUT = 30
 
 
 class HomeAssistantController(BaseController):
@@ -22,12 +23,14 @@ class HomeAssistantController(BaseController):
         refresh_token,
         app_namespace=APP_NAMESPACE,
         app_id=APP_HOMEASSISTANT_LOVELACE,
+        hass_connect_timeout=DEFAULT_HASS_CONNECT_TIMEOUT,
     ):
         super().__init__(app_namespace, app_id)
         self.hass_url = hass_url
         self.hass_uuid = hass_uuid
         self.client_id = client_id
         self.refresh_token = refresh_token
+        self.hass_connect_timeout = hass_connect_timeout
         # {
         #   connected: boolean;
         #   showDemo: boolean;
@@ -100,7 +103,7 @@ class HomeAssistantController(BaseController):
             self._hass_connecting_event.set()
             raise
 
-        self._hass_connecting_event.wait(10)
+        self._hass_connecting_event.wait(self.hass_connect_timeout)
         try:
             if not self._hass_connecting_event.is_set():
                 self.logger.warning("_connect_hass failed for %s", self.hass_url)


### PR DESCRIPTION
I was having an issue where homeassistant dashboards would not always load correctly when casting. I also discovered I wasn't the only one experiencing this: https://github.com/home-assistant/core/issues/82823. I tracked down the source of the warning message and did some testing and confirmed the exceptions were always thrown after 10 seconds exactly. Increasing the timeout allows the dashboard to show correctly and the error messages are gone.

10 seconds seems somewhat arbitrary here and some cast devices can be slow to load. Also since a bunch of people are having this issue I think it makes sense to increase the default timeout.

Another option would be to make this configurable in the cast integration to allow users experiencing this issue to set a larger timeout.