### PR TITLE
Make optional callback functions kwarg only

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -381,7 +381,9 @@ class Chromecast:
         """Start an app on the Chromecast."""
         self.logger.info("Starting app %s", app_id)
 
-        self.socket_client.receiver_controller.launch_app(app_id, force_launch)
+        self.socket_client.receiver_controller.launch_app(
+            app_id, force_launch=force_launch
+        )
 
     def quit_app(self):
         """Tells the Chromecast to quit current app_id."""
@@ -393,7 +395,7 @@ class Chromecast:
 
         stop_app_done = threading.Event()
         self.socket_client.receiver_controller.stop_app(
-            callback_function_param=stop_app_callback
+            callback_function=stop_app_callback
         )
         stop_app_done.wait(10)
         if not stop_app_done.is_set():

--- a/pychromecast/controllers/__init__.py
+++ b/pychromecast/controllers/__init__.py
@@ -53,7 +53,7 @@ class BaseController(abc.ABC):
             and self.namespace in self._socket_client.app_namespaces
         )
 
-    def launch(self, callback_function=None, force_launch=False):
+    def launch(self, *, callback_function=None, force_launch=False):
         """If set, launches app related to the controller."""
         self._check_registered()
 
@@ -86,6 +86,7 @@ class BaseController(abc.ABC):
     def send_message(
         self,
         data,
+        *,
         inc_session_id=False,
         callback_function=None,
         no_add_request_id=False,
@@ -107,8 +108,8 @@ class BaseController(abc.ABC):
                 self.launch(
                     callback_function=lambda: self.send_message_nocheck(
                         data,
-                        inc_session_id,
-                        callback_function,
+                        inc_session_id=inc_session_id,
+                        callback_function=callback_function,
                         no_add_request_id=no_add_request_id,
                     )
                 )
@@ -119,12 +120,16 @@ class BaseController(abc.ABC):
             )
 
         self.send_message_nocheck(
-            data, inc_session_id, callback_function, no_add_request_id=no_add_request_id
+            data,
+            inc_session_id=inc_session_id,
+            callback_function=callback_function,
+            no_add_request_id=no_add_request_id,
         )
 
     def send_message_nocheck(
         self,
         data,
+        *,
         inc_session_id=False,
         callback_function=None,
         no_add_request_id=False,
@@ -133,8 +138,8 @@ class BaseController(abc.ABC):
         self._message_func(
             self.namespace,
             data,
-            inc_session_id,
-            callback_function,
+            inc_session_id=inc_session_id,
+            callback_function=callback_function,
             no_add_request_id=no_add_request_id,
         )
 

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -370,6 +370,7 @@ class BaseMediaPlayer(BaseController):
         self,
         url,
         content_type,
+        *,
         title=None,
         thumb=None,
         current_time=None,
@@ -436,19 +437,19 @@ class BaseMediaPlayer(BaseController):
         self,
         url,
         content_type,
-        title=None,
-        thumb=None,
-        current_time=None,
-        autoplay=True,
-        stream_type=STREAM_TYPE_BUFFERED,
-        metadata=None,
-        subtitles=None,
-        subtitles_lang="en-US",
-        subtitles_mime="text/vtt",
-        subtitle_id=1,
-        enqueue=False,
-        media_info=None,
-        callback_function=None,
+        title,
+        thumb,
+        current_time,
+        autoplay,
+        stream_type,
+        metadata,
+        subtitles,
+        subtitles_lang,
+        subtitles_mime,
+        subtitle_id,
+        enqueue,
+        media_info,
+        callback_function,
     ):
         media_info = media_info or {}
         media = {
@@ -587,10 +588,10 @@ class MediaController(BaseMediaPlayer):
         call listener.new_media_status(status)"""
         self._status_listeners.append(listener)
 
-    def update_status(self, callback_function_param=False):
+    def update_status(self, *, callback_function=None):
         """Send message to update the status."""
         self.send_message(
-            {MESSAGE_TYPE: TYPE_GET_STATUS}, callback_function=callback_function_param
+            {MESSAGE_TYPE: TYPE_GET_STATUS}, callback_function=callback_function
         )
 
     def _send_command(self, command):

--- a/pychromecast/controllers/plex.py
+++ b/pychromecast/controllers/plex.py
@@ -342,7 +342,7 @@ class PlexController(BaseController):
         def callback():  # pylint: disable=missing-docstring
             self._send_cmd(msg, inc_session_id=True, inc=False)
 
-        self.launch(callback)
+        self.launch(callback_function=callback)
 
     def quit_app(self):
         """Quit the Plex app."""
@@ -443,7 +443,7 @@ class PlexController(BaseController):
             finally:
                 self.play_media_event.set()
 
-        self.launch(app_launched_callback)
+        self.launch(callback_function=app_launched_callback)
 
     def join(self, timeout=None):
         """Join the thread."""

--- a/pychromecast/controllers/receiver.py
+++ b/pychromecast/controllers/receiver.py
@@ -124,14 +124,14 @@ class ReceiverController(BaseController):
         listener.new_launch_error(launch_failure)"""
         self._launch_error_listeners.append(listener)
 
-    def update_status(self, callback_function_param=False):
+    def update_status(self, *, callback_function=None):
         """Sends a message to the Chromecast to update the status."""
         self.logger.debug("Receiver:Updating status")
         self.send_message(
-            {MESSAGE_TYPE: TYPE_GET_STATUS}, callback_function=callback_function_param
+            {MESSAGE_TYPE: TYPE_GET_STATUS}, callback_function=callback_function
         )
 
-    def launch_app(self, app_id, force_launch=False, callback_function=False):
+    def launch_app(self, app_id, *, force_launch=False, callback_function=None):
         """Launches an app on the Chromecast.
 
         Will only launch if it is not currently running unless
@@ -139,14 +139,14 @@ class ReceiverController(BaseController):
 
         if not force_launch and self.status is None:
             self.update_status(
-                lambda response: self._send_launch_message(
+                callback_function=lambda response: self._send_launch_message(
                     app_id, force_launch, callback_function
                 )
             )
         else:
             self._send_launch_message(app_id, force_launch, callback_function)
 
-    def _send_launch_message(self, app_id, force_launch=False, callback_function=False):
+    def _send_launch_message(self, app_id, force_launch=False, callback_function=None):
         if force_launch or self.app_id != app_id:
             self.logger.info("Receiver:Launching app %s", app_id)
 
@@ -168,13 +168,13 @@ class ReceiverController(BaseController):
             if callback_function:
                 callback_function()
 
-    def stop_app(self, callback_function_param=False):
+    def stop_app(self, *, callback_function=None):
         """Stops the current running app on the Chromecast."""
         self.logger.info("Receiver:Stopping current app '%s'", self.app_id)
         return self.send_message(
             {MESSAGE_TYPE: "STOP"},
             inc_session_id=True,
-            callback_function=callback_function_param,
+            callback_function=callback_function,
         )
 
     def set_volume(self, volume):

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -859,8 +859,9 @@ class SocketClient(threading.Thread):
         destination_id,
         namespace,
         data,
+        *,
         inc_session_id=False,
-        callback_function=False,
+        callback_function=None,
         no_add_request_id=False,
         force=False,
     ):
@@ -931,8 +932,9 @@ class SocketClient(threading.Thread):
         self,
         namespace,
         message,
+        *,
         inc_session_id=False,
-        callback_function_param=False,
+        callback_function=None,
         no_add_request_id=False,
     ):
         """Helper method to send a message to the platform."""
@@ -940,8 +942,8 @@ class SocketClient(threading.Thread):
             PLATFORM_DESTINATION_ID,
             namespace,
             message,
-            inc_session_id,
-            callback_function_param,
+            inc_session_id=inc_session_id,
+            callback_function=callback_function,
             no_add_request_id=no_add_request_id,
         )
 
@@ -949,8 +951,9 @@ class SocketClient(threading.Thread):
         self,
         namespace,
         message,
+        *,
         inc_session_id=False,
-        callback_function_param=False,
+        callback_function=None,
         no_add_request_id=False,
     ):
         """Helper method to send a message to current running app."""
@@ -964,8 +967,8 @@ class SocketClient(threading.Thread):
             self.destination_id,
             namespace,
             message,
-            inc_session_id,
-            callback_function_param,
+            inc_session_id=inc_session_id,
+            callback_function=callback_function,
             no_add_request_id=no_add_request_id,
         )
 


### PR DESCRIPTION
## Breaking change

Most user facing functions accepting an optional callback function have been changed such that the optional arguments are not kwarg only

## Change

Make optional callback functions kwarg only

## Background

This is the first step in refactoring the callback functions to accept a bool status and an optional response.

Refactoring the callback handling is needed because callbacks are currently only called if the request suceeds; there's no call if the request fails. This means any user relying on callbacks will hang forever or until a timeout when the request fails.