### PR TITLE
Remove impossible exception handling in youtube controller

### DIFF
--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -83,11 +83,7 @@ class YouTubeController(BaseController):
         (send message will launch app if it is not running).
         """
         self.status_update_event.clear()
-        # This gets the screenId but always throws. Couldn't find a better way.
-        try:
-            self.send_message({MESSAGE_TYPE: TYPE_GET_SCREEN_ID})
-        except UnsupportedNamespace:
-            pass
+        self.send_message({MESSAGE_TYPE: TYPE_GET_SCREEN_ID})
         status = self.status_update_event.wait(10)
         if not status:
             _LOGGER.warning("Failed to update screen_id")

--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -8,7 +8,6 @@ from casttube import YouTubeSession
 
 from . import BaseController
 from ..const import MESSAGE_TYPE
-from ..error import UnsupportedNamespace
 from ..config import APP_YOUTUBE
 
 YOUTUBE_NAMESPACE = "urn:x-cast:com.google.youtube.mdx"


### PR DESCRIPTION
The comment for the removed exception handling claims:
> This gets the screenId but always throws

However, this is impossible, there's no case where we send a message and after that raise `UnsupportedNamespace`