### PR TITLE
Change callbacks to be passed status and result

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -23,9 +23,10 @@ from .discovery import (  # noqa: F401
     stop_discovery,
 )
 from .dial import get_cast_type
-from .const import CAST_TYPE_CHROMECAST, SERVICE_TYPE_HOST
+from .const import CAST_TYPE_CHROMECAST, REQUEST_TIMEOUT, SERVICE_TYPE_HOST
 from .controllers.media import STREAM_TYPE_BUFFERED  # noqa: F401
 from .models import CastInfo
+from .response_handler import WaitResponse
 
 __all__ = ("get_chromecasts", "Chromecast")
 
@@ -377,46 +378,42 @@ class Chromecast:
         if status:
             self.status_event.set()
 
-    def start_app(self, app_id, force_launch=False):
+    def start_app(self, app_id, force_launch=False, timeout=REQUEST_TIMEOUT):
         """Start an app on the Chromecast."""
         self.logger.info("Starting app %s", app_id)
 
+        response_handler = WaitResponse(timeout)
         self.socket_client.receiver_controller.launch_app(
-            app_id, force_launch=force_launch
+            app_id, force_launch=force_launch, callback_function=response_handler.callback
         )
+        response_handler.wait_response()
 
-    def quit_app(self):
+    def quit_app(self, timeout=REQUEST_TIMEOUT):
         """Tells the Chromecast to quit current app_id."""
         self.logger.info("Quitting current app")
 
-        def stop_app_callback(_response):
-            """Set event when stop app request has been handled."""
-            stop_app_done.set()
-
-        stop_app_done = threading.Event()
+        response_handler = WaitResponse(timeout)
         self.socket_client.receiver_controller.stop_app(
-            callback_function=stop_app_callback
+            callback_function=response_handler.callback
         )
-        stop_app_done.wait(10)
-        if not stop_app_done.is_set():
-            self.logger.warning("Failed to stop app")
+        response_handler.wait_response()
 
-    def volume_up(self, delta=0.1):
+    def volume_up(self, delta=0.1, timeout=REQUEST_TIMEOUT):
         """Increment volume by 0.1 (or delta) unless it is already maxed.
         Returns the new volume.
 
         """
         if delta <= 0:
             raise ValueError(f"volume delta must be greater than zero, not {delta}")
-        return self.set_volume(self.status.volume_level + delta)
+        return self.set_volume(self.status.volume_level + delta, timeout=timeout)
 
-    def volume_down(self, delta=0.1):
+    def volume_down(self, delta=0.1, timeout=REQUEST_TIMEOUT):
         """Decrement the volume by 0.1 (or delta) unless it is already 0.
         Returns the new volume.
         """
         if delta <= 0:
             raise ValueError(f"volume delta must be greater than zero, not {delta}")
-        return self.set_volume(self.status.volume_level - delta)
+        return self.set_volume(self.status.volume_level - delta, timeout=timeout)
 
     def wait(self, timeout=None):
         """

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -384,7 +384,9 @@ class Chromecast:
 
         response_handler = WaitResponse(timeout)
         self.socket_client.receiver_controller.launch_app(
-            app_id, force_launch=force_launch, callback_function=response_handler.callback
+            app_id,
+            force_launch=force_launch,
+            callback_function=response_handler.callback,
         )
         response_handler.wait_response()
 

--- a/pychromecast/const.py
+++ b/pychromecast/const.py
@@ -8,6 +8,9 @@ CAST_TYPE_AUDIO = "audio"
 # Cast Audio group device, supports only audio
 CAST_TYPE_GROUP = "group"
 
+# Default command timeout
+REQUEST_TIMEOUT = 10.0
+
 MF_CANTON = "Canton Elektronik GmbH + Co. KG"
 MF_GOOGLE = "Google Inc."
 MF_JBL = "JBL"

--- a/pychromecast/controllers/dashcast.py
+++ b/pychromecast/controllers/dashcast.py
@@ -2,6 +2,7 @@
 Controller to interface with the DashCast app namespace.
 """
 from ..config import APP_DASHCAST
+from ..response_handler import chain_on_success
 from . import BaseController
 
 
@@ -37,7 +38,7 @@ class DashCastController(BaseController):
         to reload the app.
         """
 
-        def launch_callback():
+        def launch_callback(callback_function):
             """Loads requested URL after app launched."""
             should_reload = not force and reload_seconds not in (0, None)
             reload_milliseconds = 0 if not should_reload else reload_seconds * 1000
@@ -52,4 +53,4 @@ class DashCastController(BaseController):
                 msg, inc_session_id=True, callback_function=callback_function
             )
 
-        self.launch(callback_function=launch_callback)
+        self.launch(callback_function=chain_on_success(launch_callback, callback_function))

--- a/pychromecast/controllers/dashcast.py
+++ b/pychromecast/controllers/dashcast.py
@@ -53,4 +53,6 @@ class DashCastController(BaseController):
                 msg, inc_session_id=True, callback_function=callback_function
             )
 
-        self.launch(callback_function=chain_on_success(launch_callback, callback_function))
+        self.launch(
+            callback_function=chain_on_success(launch_callback, callback_function)
+        )

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -532,10 +532,7 @@ class BaseMediaPlayer(BaseController):
 
         response_handler = WaitResponse(30)
         self.play_media(
-            media_id,
-            media_type,
-            **kwargs,
-            callback_function=response_handler.callback
+            media_id, media_type, **kwargs, callback_function=response_handler.callback
         )
         request_completed = response_handler.wait_response()
 

--- a/pychromecast/controllers/plex.py
+++ b/pychromecast/controllers/plex.py
@@ -445,9 +445,7 @@ class PlexController(BaseController):
         """
         self.play_media_event.clear()
 
-        def app_launched_callback(
-            msg_sent: bool, _response: dict | None
-        ) -> None:
+        def app_launched_callback(msg_sent: bool, _response: dict | None) -> None:
             if not msg_sent:
                 raise RequestFailed("PlexController.play_media")
             try:

--- a/pychromecast/controllers/plex.py
+++ b/pychromecast/controllers/plex.py
@@ -1,6 +1,7 @@
 """
 Controller to interface with the Plex-app.
 """
+from functools import partial
 import json
 import threading
 
@@ -9,6 +10,8 @@ from urllib.parse import urlparse
 
 from . import BaseController
 from ..const import MESSAGE_TYPE
+from ..error import RequestFailed
+from ..response_handler import chain_on_success
 
 STREAM_TYPE_UNKNOWN = "UNKNOWN"
 STREAM_TYPE_BUFFERED = "BUFFERED"
@@ -339,10 +342,15 @@ class PlexController(BaseController):
             media, type=TYPE_DETAILS, requestId=self._inc_request(), **kwargs
         )
 
-        def callback():  # pylint: disable=missing-docstring
-            self._send_cmd(msg, inc_session_id=True, inc=False)
+        def callback(msg_sent, _response):
+            if not msg_sent:
+                raise RequestFailed("PlexController.show_media")
 
-        self.launch(callback_function=callback)
+        self.launch(
+            callback_function=chain_on_success(
+                partial(self._send_cmd, msg, inc_session_id=True, inc=False), callback
+            )
+        )
 
     def quit_app(self):
         """Quit the Plex app."""
@@ -437,7 +445,11 @@ class PlexController(BaseController):
         """
         self.play_media_event.clear()
 
-        def app_launched_callback():  # pylint: disable=missing-docstring
+        def app_launched_callback(
+            msg_sent: bool, _response: dict | None
+        ) -> None:
+            if not msg_sent:
+                raise RequestFailed("PlexController.play_media")
             try:
                 self._send_start_play(media, **kwargs)
             finally:

--- a/pychromecast/controllers/supla.py
+++ b/pychromecast/controllers/supla.py
@@ -6,7 +6,7 @@ import logging
 from . import BaseController
 from ..config import APP_SUPLA
 from ..error import PyChromecastError
-from .. response_handler import WaitResponse
+from ..response_handler import WaitResponse
 
 APP_NAMESPACE = "urn:x-cast:fi.ruutu.chromecast"
 
@@ -60,7 +60,5 @@ class SuplaController(BaseController):
         request_completed = response_handler.wait_response()
 
         if not request_completed or not response_handler.msg_sent:
-            self.logger.warning(
-                "Quick Play failed for %s:(%s)", media_id, kwargs
-            )
+            self.logger.warning("Quick Play failed for %s:(%s)", media_id, kwargs)
             raise PyChromecastError()  # pylint: disable=broad-exception-raised

--- a/pychromecast/controllers/yleareena.py
+++ b/pychromecast/controllers/yleareena.py
@@ -5,7 +5,7 @@ Controller to interface with the Yle Areena app namespace.
 from .media import BaseMediaPlayer, STREAM_TYPE_BUFFERED, TYPE_LOAD, MESSAGE_TYPE
 from ..config import APP_YLEAREENA
 from ..error import PyChromecastError
-from .. response_handler import WaitResponse
+from ..response_handler import WaitResponse
 
 
 class YleAreenaController(BaseMediaPlayer):
@@ -67,7 +67,5 @@ class YleAreenaController(BaseMediaPlayer):
         request_completed = response_handler.wait_response()
 
         if not request_completed or not response_handler.msg_sent:
-            self.logger.warning(
-                "Quick Play failed for %s:(%s)", media_id, kwargs
-            )
+            self.logger.warning("Quick Play failed for %s:(%s)", media_id, kwargs)
             raise PyChromecastError()  # pylint: disable=broad-exception-raised

--- a/pychromecast/controllers/yleareena.py
+++ b/pychromecast/controllers/yleareena.py
@@ -2,11 +2,10 @@
 Controller to interface with the Yle Areena app namespace.
 """
 
-import threading
-
 from .media import BaseMediaPlayer, STREAM_TYPE_BUFFERED, TYPE_LOAD, MESSAGE_TYPE
 from ..config import APP_YLEAREENA
 from ..error import PyChromecastError
+from .. response_handler import WaitResponse
 
 
 class YleAreenaController(BaseMediaPlayer):
@@ -57,19 +56,18 @@ class YleAreenaController(BaseMediaPlayer):
     # pylint: disable-next=arguments-differ
     def quick_play(self, media_id=None, audio_lang="", text_lang="off", **kwargs):
         """Quick Play"""
-        play_media_done_event = threading.Event()
-
-        def play_media_done(_):
-            play_media_done_event.set()
-
+        response_handler = WaitResponse(10)
         self.play_areena_media(
             media_id,
             audio_language=audio_lang,
             text_language=text_lang,
-            callback_function=play_media_done,
-            **kwargs
+            **kwargs,
+            callback_function=response_handler.callback
         )
+        request_completed = response_handler.wait_response()
 
-        play_media_done_event.wait(10)
-        if not play_media_done_event.is_set():
+        if not request_completed or not response_handler.msg_sent:
+            self.logger.warning(
+                "Quick Play failed for %s:(%s)", media_id, kwargs
+            )
             raise PyChromecastError()  # pylint: disable=broad-exception-raised

--- a/pychromecast/error.py
+++ b/pychromecast/error.py
@@ -56,6 +56,7 @@ class ControllerNotRegistered(PyChromecastError):
 
 class RequestFailed(PyChromecastError):
     """Raised when a request failed to complete."""
+
     MSG = "Failed to execute {request}."
 
     def __init__(self, request: str) -> None:

--- a/pychromecast/error.py
+++ b/pychromecast/error.py
@@ -52,3 +52,11 @@ class ControllerNotRegistered(PyChromecastError):
     Raised when trying to interact with a controller while it is
     not registered with a ChromeCast object.
     """
+
+
+class RequestFailed(PyChromecastError):
+    """Raised when a request failed to complete."""
+    MSG = "Failed to execute {request}."
+
+    def __init__(self, request: str) -> None:
+        super().__init__(self.MSG.format(request=request))

--- a/pychromecast/response_handler.py
+++ b/pychromecast/response_handler.py
@@ -1,0 +1,62 @@
+"""Helpers and types related to waiting for a command response."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import threading
+from typing import Protocol
+
+CallbackType = Callable[[bool, dict | None], None]
+"""Signature of optional callback functions supported by methods sending messages.
+
+The callback function will be called with a bool indicating if the message was sent
+and an optional response dict.
+"""
+
+
+class AcceptsCallbackFunc(Protocol):
+    """A function which accepts a callback_function kwarg."""
+
+    def __call__(
+        self,
+        *,
+        callback_function: CallbackType | None = None,
+    ):
+        ...
+
+
+class WaitResponse:
+    """Wait for a response."""
+
+    msg_sent: bool
+    response: dict | None
+
+    def __init__(self, timeout: float) -> None:
+        """Initialize."""
+        self._event = threading.Event()
+        self._timeout = timeout
+
+    def callback(self, msg_sent: bool, response: dict | None) -> None:
+        """Called when the request is finished."""
+        self.response = response
+        self.msg_sent = msg_sent
+        self._event.set()
+
+    def wait_response(self) -> bool:
+        """Wait for the request to finish."""
+        return self._event.wait(self._timeout)
+
+
+def chain_on_success(
+    on_success: AcceptsCallbackFunc, callback_function: CallbackType | None
+) -> CallbackType:
+    """Helper to chain callbacks."""
+
+    def _callback(msg_sent: bool, response: dict | None) -> None:
+        if not msg_sent:
+            if callback_function:
+                callback_function(msg_sent, response)
+            return
+        on_success(callback_function=callback_function)
+
+    return _callback


### PR DESCRIPTION
## Breaking change

The signature of callbacks called when requests are completed has been changed:
- The callbacks must now accept a bool status and an optional dict with response
- The callbacks will be called both in case the request succeeds and when it doesn't

New callback signature:
```py
CallbackType = Callable[[bool, dict | None], None]
"""Signature of optional callback functions supported by methods sending messages.

The callback function will be called with a bool indicating if the message was sent
and an optional response dict.
"""
```

## Change

Callback functions are now called not only on success but also on error. This prevents failing requests from hanging forever. Also, many user facing functions which send messages to the remote device but do not accept a callback now accept a timeout parameter.

Background in PR https://github.com/home-assistant-libs/pychromecast/pull/779

Needs https://github.com/home-assistant-libs/pychromecast/pull/784