### PR TITLE
Make optional callback functions kwarg only in plex

### DIFF
--- a/pychromecast/controllers/plex.py
+++ b/pychromecast/controllers/plex.py
@@ -260,10 +260,10 @@ class PlexController(BaseController):
 
         return False
 
-    def update_status(self, callback_function_param=False):
+    def update_status(self, *, callback_function= None):
         """Send message to update status."""
         self.send_message(
-            {MESSAGE_TYPE: TYPE_GET_STATUS}, callback_function=callback_function_param
+            {MESSAGE_TYPE: TYPE_GET_STATUS}, callback_function=callback_function
         )
 
     def stop(self):

--- a/pychromecast/controllers/plex.py
+++ b/pychromecast/controllers/plex.py
@@ -260,7 +260,7 @@ class PlexController(BaseController):
 
         return False
 
-    def update_status(self, *, callback_function= None):
+    def update_status(self, *, callback_function=None):
         """Send message to update status."""
         self.send_message(
             {MESSAGE_TYPE: TYPE_GET_STATUS}, callback_function=callback_function


### PR DESCRIPTION
## Breaking change

User facing functions in the plex controller which accept an optional callback function have been changed such that the optional arguments are now kwarg only

## Change

Make optional callback functions kwarg only in dashcast

Background in PR https://github.com/home-assistant-libs/pychromecast/pull/779