### PR TITLE
Fix iteration over message handlers

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -512,7 +512,7 @@ class SocketClient(threading.Thread):
             for namespace in self.app_namespaces:
                 if namespace in self._handlers:
                     self._ensure_channel_connected(self.destination_id)
-                    for handler in self._handlers[namespace]:
+                    for handler in set(self._handlers[namespace]):
                         handler.channel_connected()
 
     def _gen_request_id(self):
@@ -730,7 +730,7 @@ class SocketClient(threading.Thread):
                 )
 
             # message handlers
-            for handler in self._handlers[message.namespace]:
+            for handler in set(self._handlers[message.namespace]):
                 try:
                     handled = handler.receive_message(message, data)
 
@@ -773,8 +773,8 @@ class SocketClient(threading.Thread):
             except Exception:  # pylint: disable=broad-except
                 pass
 
-        for namespace in self._handlers.values():
-            for handler in namespace:
+        for handlers in self._handlers.values():
+            for handler in set(handlers):
                 try:
                     handler.tear_down()
                 except Exception:  # pylint: disable=broad-except
@@ -1050,7 +1050,7 @@ class SocketClient(threading.Thread):
         """Handles a channel being disconnected."""
         for namespace in self.app_namespaces:
             if namespace in self._handlers:
-                for handler in self._handlers[namespace]:
+                for handler in set(self._handlers[namespace]):
                     handler.channel_disconnected()
 
         self.app_namespaces = []


### PR DESCRIPTION
Handling of a message may cause a controller to unregister itself. Without the changes in this PR, this leads to a runtime error:
```
2024-01-19 11:58:15.996 ERROR (Thread-8) [pychromecast.socket_client] [Cellar display(192.168.0.114):8009] Unhandled exception in worker thread, attempting reconnect
Traceback (most recent call last):
  File "/home/erik/development/pychromecast_fork/pychromecast/socket_client.py", line 564, in run
    if self.run_once(timeout=POLL_TIME_BLOCKING) == 1:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/erik/development/pychromecast_fork/pychromecast/socket_client.py", line 669, in run_once
    self._route_message(message, data)
  File "/home/erik/development/pychromecast_fork/pychromecast/socket_client.py", line 741, in _route_message
    for handler in self._handlers[message.namespace]:
RuntimeError: Set changed size during iteration
```