### PR TITLE
Retry launching app

### DIFF
--- a/pychromecast/controllers/receiver.py
+++ b/pychromecast/controllers/receiver.py
@@ -187,7 +187,7 @@ class ReceiverController(BaseController):
 
             def handle_launch_response(msg_sent: bool, response: dict | None) -> None:
                 if (
-                    msg_sent
+                    msg_sent  # pylint: disable=too-many-boolean-expressions
                     and response
                     and response.get(MESSAGE_TYPE) == TYPE_LAUNCH_ERROR
                     and response.get(ERROR_REASON) == LAUNCH_CANCELLED


### PR DESCRIPTION
Retry launching app if it fails with reason `CANCELLED`

This error is seen almost every time when the dashcast app is active and we request launching another app.

If the user has registered a launch error listener, we do not retry but expect the user to handle the error as needed.