### PR TITLE
Correct generating cast messages

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -105,11 +105,6 @@ def _message_to_string(message, data=None):
     )
 
 
-def _json_to_payload(data: dict) -> bytes:
-    """Encodes a python value into JSON format."""
-    return json.dumps(data, ensure_ascii=False).encode("utf8")
-
-
 @dataclass(frozen=True)
 class NetworkAddress:
     """Network address container."""
@@ -877,7 +872,7 @@ class SocketClient(threading.Thread):
             cast_channel_pb2.CastMessage.STRING  # pylint: disable=no-member
         )
         msg.namespace = namespace
-        msg.payload_utf8 = _json_to_payload(data)
+        msg.payload_utf8 = json.dumps(data, ensure_ascii=False)
 
         # prepend message with Big-Endian 4 byte payload size
         be_size = pack(">I", msg.ByteSize())


### PR DESCRIPTION
Without this PR, we first encode to bytes, protobuf will decode the bytes to str and then finally encode it again.

See: https://github.com/home-assistant-libs/pychromecast/pull/805#discussion_r1468856946