### PR TITLE
Improve logging in example scripts

### DIFF
--- a/examples/bbciplayer_example.py
+++ b/examples/bbciplayer_example.py
@@ -13,6 +13,12 @@ import zeroconf
 import pychromecast
 from pychromecast import quick_play
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the name of your Chromecast
 CAST_NAME = "Lounge Video"
 
@@ -43,6 +49,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -60,7 +69,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/bbcsounds_example.py
+++ b/examples/bbcsounds_example.py
@@ -13,6 +13,12 @@ import zeroconf
 import pychromecast
 from pychromecast import quick_play
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the name of your Chromecast
 CAST_NAME = "Lounge Video"
 
@@ -50,6 +56,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -71,7 +80,14 @@ if args.media_id == MEDIA_ID:
     args.is_live = DEFAULT_MEDIA_ID_IS_LIVE
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/bubbleupnp_example.py
+++ b/examples/bubbleupnp_example.py
@@ -15,6 +15,12 @@ import pychromecast
 from pychromecast import quick_play
 
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Kitchen speaker"
 
@@ -37,6 +43,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -48,7 +57,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/dashcast_example.py
+++ b/examples/dashcast_example.py
@@ -13,6 +13,12 @@ import zeroconf
 import pychromecast
 from pychromecast.controllers import dashcast
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Living Room"
 
@@ -29,12 +35,22 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/default_media_receiver_example.py
+++ b/examples/default_media_receiver_example.py
@@ -14,6 +14,11 @@ import zeroconf
 import pychromecast
 from pychromecast import quick_play
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
 
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Kitchen speaker"
@@ -36,6 +41,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -44,7 +52,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/discovery_example.py
+++ b/examples/discovery_example.py
@@ -5,6 +5,7 @@ Example that shows how to receive updates on discovered chromecasts.
 
 import argparse
 import logging
+import sys
 import time
 from uuid import UUID
 
@@ -12,6 +13,12 @@ import zeroconf
 
 import pychromecast
 from pychromecast import CastInfo
+
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
 
 parser = argparse.ArgumentParser(
     description="Example on how to receive updates on discovered chromecasts."
@@ -28,6 +35,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -36,7 +46,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/discovery_example2.py
+++ b/examples/discovery_example2.py
@@ -5,10 +5,17 @@ Example that shows how to list all available chromecasts.
 
 import argparse
 import logging
+import sys
 
 import zeroconf
 
 import pychromecast
+
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
 
 parser = argparse.ArgumentParser(
     description="Example that shows how to list all available chromecasts."
@@ -20,6 +27,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -28,7 +38,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/discovery_example3.py
+++ b/examples/discovery_example3.py
@@ -12,6 +12,12 @@ import zeroconf
 
 import pychromecast
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 parser = argparse.ArgumentParser(
     description="Example that shows how to list chromecasts matching on name or uuid."
 )
@@ -24,6 +30,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -32,7 +41,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/get_chromecasts.py
+++ b/examples/get_chromecasts.py
@@ -11,6 +11,12 @@ import zeroconf
 
 import pychromecast
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 parser = argparse.ArgumentParser(
     description="Example on how to connect to all chromecasts."
 )
@@ -21,12 +27,22 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/homeassistant_media_example.py
+++ b/examples/homeassistant_media_example.py
@@ -15,6 +15,12 @@ import pychromecast
 from pychromecast import quick_play
 
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Kitchen speaker"
 
@@ -36,6 +42,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -44,7 +53,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/media_enqueue.py
+++ b/examples/media_enqueue.py
@@ -36,12 +36,22 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/media_enqueue.py
+++ b/examples/media_enqueue.py
@@ -13,6 +13,12 @@ import zeroconf
 
 import pychromecast
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Living Room"
 

--- a/examples/media_example.py
+++ b/examples/media_example.py
@@ -13,6 +13,12 @@ import zeroconf
 
 import pychromecast
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Living Room"
 
@@ -23,6 +29,9 @@ parser = argparse.ArgumentParser(
     description="Example on how to use the Media Controller to play an URL."
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
+parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
 parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
@@ -40,7 +49,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/media_example2.py
+++ b/examples/media_example2.py
@@ -13,6 +13,12 @@ import zeroconf
 
 import pychromecast
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Living Room"
 
@@ -32,9 +38,12 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
     "--show-status-only", help="Show status, then exit", action="store_true"
+)
+parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
+parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
 )
 parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
@@ -48,6 +57,11 @@ if args.show_debug:
     fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
     logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/multizone_example.py
+++ b/examples/multizone_example.py
@@ -18,6 +18,12 @@ from pychromecast.controllers.multizone import (
 )
 from pychromecast.socket_client import ConnectionStatus, ConnectionStatusListener
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the name of your Chromecast
 CAST_NAME = "Whole house"
 
@@ -34,12 +40,22 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/nrkradio_example.py
+++ b/examples/nrkradio_example.py
@@ -13,6 +13,12 @@ import zeroconf
 import pychromecast
 from pychromecast import quick_play
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Living Room"
 
@@ -37,6 +43,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -45,7 +54,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/nrktv_example.py
+++ b/examples/nrktv_example.py
@@ -13,6 +13,12 @@ import zeroconf
 import pychromecast
 from pychromecast import quick_play
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Living Room"
 
@@ -36,6 +42,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -45,7 +54,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/plex_multi_example.py
+++ b/examples/plex_multi_example.py
@@ -30,6 +30,12 @@ import zeroconf
 import pychromecast
 from pychromecast.controllers.plex import PlexController
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 
 # Change to the friendly name of your Chromecast.
 CAST_NAME = "Office TV"
@@ -66,6 +72,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -90,7 +99,14 @@ parser.add_argument(
 
 args = parser.parse_args()
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/shaka_drm_example.py
+++ b/examples/shaka_drm_example.py
@@ -15,6 +15,12 @@ import zeroconf
 import pychromecast
 from pychromecast import quick_play
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Living Room"
@@ -36,6 +42,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -44,7 +53,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/simple_listener_example.py
+++ b/examples/simple_listener_example.py
@@ -14,6 +14,12 @@ import pychromecast
 from pychromecast.controllers.media import MediaStatus, MediaStatusListener
 from pychromecast.controllers.receiver import CastStatusListener
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the friendly name of your Chromecast
 CAST_NAME = "Living Room Speaker"
 
@@ -67,12 +73,22 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/supla_example.py
+++ b/examples/supla_example.py
@@ -15,6 +15,12 @@ import pychromecast
 from pychromecast import quick_play
 
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the name of your Chromecast
 CAST_NAME = "Kitchen Speaker"
 

--- a/examples/yleareena_example.py
+++ b/examples/yleareena_example.py
@@ -16,6 +16,12 @@ from pychromecast import quick_play
 logger = logging.getLogger(__name__)
 
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the name of your Chromecast
 CAST_NAME = "My Chromecast"
 
@@ -32,6 +38,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument("--program", help="Areena Program ID", default="1-50649659")
@@ -40,7 +49,14 @@ parser.add_argument("--text_language", help="text_language", default="off")
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/youtube_example.py
+++ b/examples/youtube_example.py
@@ -13,6 +13,12 @@ import pychromecast
 from pychromecast.controllers.youtube import YouTubeController
 
 
+# Enable deprecation warnings etc.
+if not sys.warnoptions:
+    import warnings
+
+    warnings.simplefilter("default")
+
 # Change to the name of your Chromecast
 CAST_NAME = "Living Room TV"
 
@@ -34,6 +40,9 @@ parser.add_argument(
 )
 parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
 parser.add_argument(
+    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+)
+parser.add_argument(
     "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
 )
 parser.add_argument(
@@ -42,7 +51,14 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.show_debug:
-    logging.basicConfig(level=logging.DEBUG)
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
+    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+if args.show_discovery_debug:
+    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
 if args.show_zeroconf_debug:
     print("Zeroconf version: " + zeroconf.__version__)
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)


### PR DESCRIPTION
Improve logging in example scripts:
- Enable print of Python deprecation warnings etc.
- Add a separate flag to control log level of discovery
- Prefix log messages with timestamp and thread name