### PR TITLE
Fix deprecated call to ssl.SSLContext without specifying protocol

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -352,7 +352,9 @@ class SocketClient(threading.Thread, CastStatusListener):
                         self.port,
                     )
                     self.socket.connect((self.host, self.port))
-                    context = ssl.SSLContext()
+                    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                    context.check_hostname = False
+                    context.verify_mode = ssl.CERT_NONE
                     self.socket = context.wrap_socket(self.socket)
                     self.connecting = False
                     self._force_recon = False


### PR DESCRIPTION
Same change as in https://github.com/home-assistant-libs/pychromecast/pull/763 + https://github.com/home-assistant-libs/pychromecast/pull/764, but for `SocketClient`