### PR TITLE
Deduplicate log setup in examples

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,5 @@
+"""Example scripts.
+
+Scripts need to be invoked with the -m flag, e.g.:
+python3 -m examples.youtube_example --cast "Kitchen" --show-debug
+"""

--- a/examples/bbciplayer_example.py
+++ b/examples/bbciplayer_example.py
@@ -4,14 +4,14 @@ Example on how to use the BBC iPlayer Controller
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 from time import sleep
 import json
 
-import zeroconf
 import pychromecast
 from pychromecast import quick_play
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -47,13 +47,7 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--media_id", help='MediaID (default: "%(default)s")', default=MEDIA_ID
 )
@@ -68,18 +62,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/bbcsounds_example.py
+++ b/examples/bbcsounds_example.py
@@ -4,14 +4,14 @@ Example on how to use the BBC iPlayer Controller
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 from time import sleep
 import json
 
-import zeroconf
 import pychromecast
 from pychromecast import quick_play
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -54,13 +54,7 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--media_id", help='MediaID (default: "%(default)s")', default=MEDIA_ID
 )
@@ -79,18 +73,7 @@ args = parser.parse_args()
 if args.media_id == MEDIA_ID:
     args.is_live = DEFAULT_MEDIA_ID_IS_LIVE
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/bubbleupnp_example.py
+++ b/examples/bubbleupnp_example.py
@@ -5,15 +5,13 @@ Example on how to use the BubbleUPNP Controller to play an URL.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 from time import sleep
-
-import zeroconf
 
 import pychromecast
 from pychromecast import quick_play
 
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -41,13 +39,7 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--url", help='Media url (default: "%(default)s")', default=MEDIA_URL
 )
@@ -56,18 +48,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/common.py
+++ b/examples/common.py
@@ -1,0 +1,34 @@
+"""Common helpers and utilities shared by examples."""
+
+import argparse
+import logging
+
+import zeroconf
+
+
+def add_log_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add arguments to control logging to the parser."""
+    parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
+    parser.add_argument(
+        "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
+    )
+    parser.add_argument(
+        "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
+    )
+
+
+def configure_logging(args: argparse.Namespace) -> None:
+    """Configure logging according to command line arguments."""
+    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.INFO)
+
+    if args.show_debug:
+        logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
+        logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
+    if args.show_discovery_debug:
+        logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
+        logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
+    if args.show_zeroconf_debug:
+        print("Zeroconf version: " + zeroconf.__version__)
+        logging.getLogger("zeroconf").setLevel(logging.DEBUG)

--- a/examples/dashcast_example.py
+++ b/examples/dashcast_example.py
@@ -4,14 +4,13 @@ Example that shows how the DashCast controller can be used.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 import time
 
-import zeroconf
-
 import pychromecast
 from pychromecast.controllers import dashcast
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -33,27 +32,10 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/default_media_receiver_example.py
+++ b/examples/default_media_receiver_example.py
@@ -5,14 +5,13 @@ Example on how to use the Home Assistant Media app to play an URL.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 from time import sleep
 
-import zeroconf
-
 import pychromecast
 from pychromecast import quick_play
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -39,30 +38,13 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--url", help='Media url (default: "%(default)s")', default=MEDIA_URL
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/discovery_example.py
+++ b/examples/discovery_example.py
@@ -4,7 +4,6 @@ Example that shows how to receive updates on discovered chromecasts.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 import time
 from uuid import UUID
@@ -13,6 +12,8 @@ import zeroconf
 
 import pychromecast
 from pychromecast import CastInfo
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -33,30 +34,13 @@ parser.add_argument(
     help="Zeroconf will be used even if --known-host is present",
     action="store_true",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--verbose", help="Full display of discovered devices", action="store_true"
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 
 def list_devices() -> None:

--- a/examples/discovery_example2.py
+++ b/examples/discovery_example2.py
@@ -4,12 +4,11 @@ Example that shows how to list all available chromecasts.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 
-import zeroconf
-
 import pychromecast
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -25,30 +24,13 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--verbose", help="Full display of discovered devices", action="store_true"
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 devices, browser = pychromecast.discovery.discover_chromecasts(
     known_hosts=args.known_host

--- a/examples/discovery_example3.py
+++ b/examples/discovery_example3.py
@@ -4,13 +4,12 @@ Example that shows how to list chromecasts matching on name or uuid.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 from uuid import UUID
 
-import zeroconf
-
 import pychromecast
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -28,30 +27,13 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--verbose", help="Full display of discovered devices", action="store_true"
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 if args.cast is None and args.uuid is None:
     print("Need to supply `cast` or `uuid`")

--- a/examples/get_chromecasts.py
+++ b/examples/get_chromecasts.py
@@ -4,12 +4,11 @@ Example that shows how to connect to all chromecasts.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 
-import zeroconf
-
 import pychromecast
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -25,27 +24,10 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 casts, browser = pychromecast.get_chromecasts(known_hosts=args.known_host)
 # Shut down discovery as we don't care about updates

--- a/examples/homeassistant_media_example.py
+++ b/examples/homeassistant_media_example.py
@@ -5,14 +5,13 @@ Example on how to use the Home Assistant Media app to play an URL.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 from time import sleep
 
-import zeroconf
-
 import pychromecast
 from pychromecast import quick_play
+
+from .common import add_log_arguments, configure_logging
 
 
 # Enable deprecation warnings etc.
@@ -40,30 +39,13 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--url", help='Media url (default: "%(default)s")', default=MEDIA_URL
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/media_enqueue.py
+++ b/examples/media_enqueue.py
@@ -5,13 +5,12 @@ Example on how to use queuing with Media Controller
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 import time
 
-import zeroconf
-
 import pychromecast
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -40,27 +39,10 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/media_example.py
+++ b/examples/media_example.py
@@ -5,13 +5,12 @@ Example on how to use the Media Controller to play an URL.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 import time
 
-import zeroconf
-
 import pychromecast
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -28,13 +27,7 @@ MEDIA_URL = "https://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/das
 parser = argparse.ArgumentParser(
     description="Example on how to use the Media Controller to play an URL."
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--cast", help='Name of cast device (default: "%(default)s")', default=CAST_NAME
 )
@@ -48,18 +41,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/media_example2.py
+++ b/examples/media_example2.py
@@ -5,13 +5,12 @@ Example on how to use the Media Controller.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 import time
 
-import zeroconf
-
 import pychromecast
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -41,30 +40,13 @@ parser.add_argument(
 parser.add_argument(
     "--show-status-only", help="Show status, then exit", action="store_true"
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--url", help='Media url (default: "%(default)s")', default=MEDIA_URL
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/multizone_example.py
+++ b/examples/multizone_example.py
@@ -5,11 +5,8 @@ Example on how to use the Multizone (Audio Group) Controller
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 import time
-
-import zeroconf
 
 import pychromecast
 from pychromecast.controllers.multizone import (
@@ -17,6 +14,8 @@ from pychromecast.controllers.multizone import (
     MultiZoneControllerListener,
 )
 from pychromecast.socket_client import ConnectionStatus, ConnectionStatusListener
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -38,27 +37,10 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 
 class MyConnectionStatusListener(ConnectionStatusListener):

--- a/examples/nrkradio_example.py
+++ b/examples/nrkradio_example.py
@@ -4,14 +4,13 @@ Example on how to use the NRK Radio Controller
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 from time import sleep
 
-import zeroconf
-
 import pychromecast
 from pychromecast import quick_play
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -41,30 +40,13 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--media_id", help='MediaID (default: "%(default)s")', default=MEDIA_ID
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/nrktv_example.py
+++ b/examples/nrktv_example.py
@@ -4,14 +4,13 @@ Example on how to use the NRK TV Controller
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 from time import sleep
 
-import zeroconf
-
 import pychromecast
 from pychromecast import quick_play
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -40,31 +39,14 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--media_id", help='MediaID (default: "%(default)s")', default=MEDIA_ID
 )
 
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/plex_multi_example.py
+++ b/examples/plex_multi_example.py
@@ -20,15 +20,15 @@ pip install plexapi
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 from typing import Any
 
 from plexapi.server import PlexServer  # type: ignore[import-untyped]
-import zeroconf
 
 import pychromecast
 from pychromecast.controllers.plex import PlexController
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -70,13 +70,7 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--url", help='URL of your Plex Server (default: "%(default)s").', default=PLEX_URL
 )
@@ -98,18 +92,7 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 startItem = None
 
 

--- a/examples/shaka_drm_example.py
+++ b/examples/shaka_drm_example.py
@@ -6,14 +6,13 @@ Example on how to use the Shaka Controller to play an URL.
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 from time import sleep
 
-import zeroconf
-
 import pychromecast
 from pychromecast import quick_play
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -40,30 +39,13 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--url", help='Media url (default: "%(default)s")', default=MEDIA_URL
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/simple_listener_example.py
+++ b/examples/simple_listener_example.py
@@ -5,14 +5,14 @@ device and media status events
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
 import time
-import zeroconf
 
 import pychromecast
 from pychromecast.controllers.media import MediaStatus, MediaStatusListener
 from pychromecast.controllers.receiver import CastStatusListener
+
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -71,27 +71,10 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host

--- a/examples/yleareena_example.py
+++ b/examples/yleareena_example.py
@@ -5,16 +5,13 @@ Example on how to use the Yle Areena Controller
 # pylint: disable=invalid-name, import-outside-toplevel, too-many-locals
 
 import argparse
-import logging
 import sys
 from time import sleep
-import zeroconf
 
 import pychromecast
 from pychromecast import quick_play
 
-logger = logging.getLogger(__name__)
-
+from .common import add_log_arguments, configure_logging
 
 # Enable deprecation warnings etc.
 if not sys.warnoptions:
@@ -36,30 +33,13 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument("--program", help="Areena Program ID", default="1-50649659")
 parser.add_argument("--audio_language", help="audio_language", default="")
 parser.add_argument("--text_language", help="text_language", default="off")
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 
 def get_kaltura_id(program_id: str) -> str:

--- a/examples/youtube_example.py
+++ b/examples/youtube_example.py
@@ -5,12 +5,12 @@ Example on how to use the YouTube Controller
 # pylint: disable=invalid-name
 
 import argparse
-import logging
 import sys
-import zeroconf
 
 import pychromecast
 from pychromecast.controllers.youtube import YouTubeController
+
+from .common import add_log_arguments, configure_logging
 
 
 # Enable deprecation warnings etc.
@@ -38,30 +38,13 @@ parser.add_argument(
     help="Add known host (IP), can be used multiple times",
     action="append",
 )
-parser.add_argument("--show-debug", help="Enable debug log", action="store_true")
-parser.add_argument(
-    "--show-discovery-debug", help="Enable discovery debug log", action="store_true"
-)
-parser.add_argument(
-    "--show-zeroconf-debug", help="Enable zeroconf debug log", action="store_true"
-)
+add_log_arguments(parser)
 parser.add_argument(
     "--videoid", help='Youtube video ID (default: "%(default)s")', default=VIDEO_ID
 )
 args = parser.parse_args()
 
-if args.show_debug:
-    fmt = "%(asctime)s %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(format=fmt, datefmt=datefmt, level=logging.DEBUG)
-    logging.getLogger("pychromecast.dial").setLevel(logging.INFO)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.INFO)
-if args.show_discovery_debug:
-    logging.getLogger("pychromecast.dial").setLevel(logging.DEBUG)
-    logging.getLogger("pychromecast.discovery").setLevel(logging.DEBUG)
-if args.show_zeroconf_debug:
-    print("Zeroconf version: " + zeroconf.__version__)
-    logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+configure_logging(args)
 
 chromecasts, browser = pychromecast.get_listed_chromecasts(
     friendly_names=[args.cast], known_hosts=args.known_host


### PR DESCRIPTION
To be able to do local imports in the example scripts, examples is now a package and the example scripts need to be invoked with the `-m` flag, e.g.:
```
python3 -m examples.youtube_example --cast "Kitchen display" --show-debug
```

This is somewhat unwanted, but there doesn't seem to be any non-hacky ways around it.