### PR TITLE
Fix hostname support

### DIFF
--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -90,7 +90,8 @@ def _get_status(
             _LOGGER.debug("Resolved service %s to %s", service, host)
             break
 
-    headers = {"content-type": "application/json"}
+    # unsetting the host header, as requests with a domain would be blocked otherwise
+    headers = {"host": "", "content-type": "application/json"}
 
     if secure:
         url = FORMAT_BASE_URL_HTTPS.format(host) + path


### PR DESCRIPTION
> This PR is split from #861

A device will otherwise block the request, when requesting with a hostname instead of the plain IP. 