### PR TITLE
Expose 'manufacturer' and 'product_name' properties in 'Chromecast' class.

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -395,12 +395,28 @@ class Chromecast(CastStatusListener):
         return f"{self.socket_client.host}:{self.socket_client.port}"
 
     @property
+    def manufacturer(self) -> str:
+        """Returns the manufacturer of the Chromecast device."""
+        if TYPE_CHECKING:
+            # get_cast_type is guaranteed to return a CastInfo with a non-None model
+            assert self.cast_info.manufacturer is not None
+        return self.cast_info.manufacturer
+
+    @property
     def model_name(self) -> str:
         """Returns the model name of the Chromecast device."""
         if TYPE_CHECKING:
             # get_cast_type is guaranteed to return a CastInfo with a non-None model
             assert self.cast_info.model_name is not None
         return self.cast_info.model_name
+
+    @property
+    def product_name(self) -> str:
+        """Returns the product name of the Chromecast device."""
+        if TYPE_CHECKING:
+            # get_cast_type is guaranteed to return a CastInfo with a non-None model
+            assert self.cast_info.product_name is not None
+        return self.cast_info.product_name
 
     @property
     def cast_type(self) -> str:

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -212,6 +212,7 @@ def get_device_info(  # pylint: disable=too-many-locals
         cast_type = CAST_TYPE_CHROMECAST
         display_supported = True
         friendly_name = status.get("name", "Unknown Chromecast")
+        product_name = "Unknown product name"
         manufacturer = "Unknown manufacturer"
         model_name = "Unknown model name"
         multizone_supported = False
@@ -224,6 +225,7 @@ def get_device_info(  # pylint: disable=too-many-locals
             display_supported = capabilities.get("display_supported", True)
             multizone_supported = capabilities.get("multizone_supported", True)
             friendly_name = device_info.get("name", friendly_name)
+            product_name = device_info.get("product_name", product_name)
             model_name = device_info.get("model_name", model_name)
             manufacturer = device_info.get("manufacturer", manufacturer)
             udn = device_info.get("ssdp_udn", None)
@@ -239,6 +241,7 @@ def get_device_info(  # pylint: disable=too-many-locals
 
         return DeviceStatus(
             friendly_name,
+            product_name,
             model_name,
             manufacturer,
             uuid,
@@ -332,6 +335,7 @@ class DeviceStatus:
     """Device status container."""
 
     friendly_name: str
+    product_name: str
     model_name: str
     manufacturer: str
     uuid: UUID | None

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -348,7 +348,7 @@ class HostBrowser(threading.Thread):
         # Iterate over a copy because other threads may modify the known_hosts list
         known_hosts = list(self._known_hosts.keys())
         for host in known_hosts:
-            devices: list[tuple[int, str, str, UUID, str, str]] = []
+            devices: list[tuple[int, str, str, str, UUID, str, str]] = []
             uuids: list[UUID] = []
             if self.stop.is_set():
                 break
@@ -396,6 +396,7 @@ class HostBrowser(threading.Thread):
                 (
                     8009,
                     device_status.friendly_name,
+                    device_status.product_name,
                     device_status.model_name,
                     device_status.uuid,
                     device_status.cast_type,
@@ -425,6 +426,7 @@ class HostBrowser(threading.Thread):
                             group.port,
                             group.friendly_name,
                             "Google Cast Group",
+                            "Google Cast Group",
                             group.uuid,
                             CAST_TYPE_GROUP,
                             "Google Inc.",
@@ -437,7 +439,7 @@ class HostBrowser(threading.Thread):
     def _update_devices(
         self,
         host: str,
-        devices: list[tuple[int, str, str, UUID, str, str]],
+        devices: list[tuple[int, str, str, str, UUID, str, str]],
         host_uuids: list[UUID],
     ) -> None:
         callbacks: list[Callable[[], None]] = []
@@ -447,6 +449,7 @@ class HostBrowser(threading.Thread):
             for (
                 port,
                 friendly_name,
+                product_name,
                 model_name,
                 uuid,
                 cast_type,
@@ -456,6 +459,7 @@ class HostBrowser(threading.Thread):
                     host,
                     port,
                     friendly_name,
+                    product_name,
                     model_name,
                     uuid,
                     callbacks,
@@ -481,6 +485,7 @@ class HostBrowser(threading.Thread):
         host: str,
         port: int,
         friendly_name: str,
+        product_name: str,
         model_name: str,
         uuid: UUID,
         callbacks: list[Callable[[], None]],
@@ -496,6 +501,7 @@ class HostBrowser(threading.Thread):
             if (
                 service_info in cast_info.services
                 and cast_info.model_name == model_name
+                and cast_info.product_name == product_name
                 and cast_info.friendly_name == friendly_name
             ):
                 # No changes, return
@@ -506,6 +512,7 @@ class HostBrowser(threading.Thread):
                 {service_info},
                 uuid,
                 model_name,
+                product_name,
                 friendly_name,
                 host,
                 port,
@@ -520,6 +527,7 @@ class HostBrowser(threading.Thread):
                 services,
                 uuid,
                 model_name,
+                product_name,
                 friendly_name,
                 host,
                 port,

--- a/pychromecast/models.py
+++ b/pychromecast/models.py
@@ -23,6 +23,7 @@ class CastInfo:
     services: set[HostServiceInfo | MDNSServiceInfo]
     uuid: UUID
     model_name: str | None
+    product_name: str | None
     friendly_name: str | None
     host: str
     port: int


### PR DESCRIPTION
Expose 'manufacturer' and 'product_name' properties in 'Chromecast' class.

**[Justification]:**
Field '**model_name**' evaluates to '**Chromecast**' for all device models.
Field '**product_name**' allows to actually distinguish between Chromecast models:
- Chromecast 3 => 'caprica'
- Chromecast Ultra => 'steak'
- Chromecast Android TV => 'sabrina'