### PR TITLE
Add BRAVIA 4K VH21 to known devices

### DIFF
--- a/pychromecast/const.py
+++ b/pychromecast/const.py
@@ -43,6 +43,7 @@ CAST_TYPES = {
     "nest audio": (CAST_TYPE_AUDIO, MF_GOOGLE),
     "nest wifi point": (CAST_TYPE_AUDIO, MF_GOOGLE),
     "bravia 4k vh2": (CAST_TYPE_CHROMECAST, MF_SONY),
+    "bravia 4k vh21": (CAST_TYPE_CHROMECAST, MF_SONY),
     "C4A": (CAST_TYPE_AUDIO, MF_SONY),
     "JBL Link 10": (CAST_TYPE_AUDIO, MF_JBL),
     "JBL Link 20": (CAST_TYPE_AUDIO, MF_JBL),


### PR DESCRIPTION
I got the error:

`INFO (zeroconf-ServiceBrowser-_googlecast._tcp-1640704) [homeassistant.components.cast.helpers] Fetched cast details for unknown model 'BRAVIA 4K VH21' manufacturer: 'Sony', type: 'cast'. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+cast%22`

Following the pattern of https://github.com/home-assistant-libs/pychromecast/pull/878 and the associated issue, I figured I'd just fix it. Let me know if there are any needed modifications.
