### PR TITLE
Initialize `_session` member on YouTube controller

### DIFF
--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -77,13 +77,14 @@ class TimeoutYouTubeSession(YouTubeSession):  # type: ignore[misc]
 class YouTubeController(QuickPlayController):
     """Controller to interact with Youtube."""
 
-    _session: YouTubeSession | None = None
+    _session: YouTubeSession
     _screen_id: str | None = None
 
     def __init__(self, timeout: float = 10) -> None:
         super().__init__(YOUTUBE_NAMESPACE, APP_YOUTUBE)
         self.status_update_event = threading.Event()
         self._timeout = timeout
+        self._session = None
 
     def start_session_if_none(self) -> None:
         """

--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -77,7 +77,7 @@ class TimeoutYouTubeSession(YouTubeSession):  # type: ignore[misc]
 class YouTubeController(QuickPlayController):
     """Controller to interact with Youtube."""
 
-    _session: YouTubeSession
+    _session: YouTubeSession | None = None
     _screen_id: str | None = None
 
     def __init__(self, timeout: float = 10) -> None:


### PR DESCRIPTION
Fixes this error:

```bash
    youtube.quick_play(media_id=video_id, timeout=timeout)                                                                               
  File "~/.pyenv/versions/3.12.4/lib/python3.12/site-packages/pychromecast/controllers/youtube.py", line 182, in quick_play
    self.play_video(media_id, playlist_id=playlist_id, **kwargs)                                                                    
  File "~/.pyenv/versions/3.12.4/lib/python3.12/site-packages/pychromecast/controllers/youtube.py", line 104, in play_video
    self.start_session_if_none()
  File "~/.pyenv/versions/3.12.4/lib/python3.12/site-packages/pychromecast/controllers/youtube.py", line 92, in start_sessi
on_if_none
    if not (self._screen_id and self._session):
                                ^^^^^^^^^^^^^
AttributeError: 'YouTubeController' object has no attribute '_session'
```