### PR TITLE
Avoid logging graceful disconnect as error

### DIFF
--- a/pychromecast/error.py
+++ b/pychromecast/error.py
@@ -11,6 +11,10 @@ class ChromecastConnectionError(PyChromecastError):
     """When a connection error occurs within PyChromecast."""
 
 
+class ChromecastConnectionClosed(PyChromecastError):
+    """When a connection was closed by remote device."""
+
+
 class PyChromecastStopped(PyChromecastError):
     """Raised when a command is invoked while the Chromecast's socket_client
     is stopped.


### PR DESCRIPTION
The chromecasts restart each night, and seem to
generally do this by doing a socket shutdown of
write leading to a EOF received by clients.

No need to log this as an error