### PR TITLE
Set ciphers to DEFAULT in socket_client.py to connect with a wider range of chromecast devices

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -360,6 +360,7 @@ class SocketClient(threading.Thread, CastStatusListener):
                     context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
                     context.check_hostname = False
                     context.verify_mode = ssl.CERT_NONE
+                    context.set_ciphers('DEFAULT')
                     self.socket = context.wrap_socket(self.socket)
                     self.connecting = False
                     self._force_recon = False


### PR DESCRIPTION
Add context.set_ciphers('DEFAULT') to allow older ciphers to work