### PR TITLE
Advertise typing support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers=[
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 
 [project.urls]


### PR DESCRIPTION
This project seems great with handling typing, but it does not announce its support in a conformant fashion, so tools like Pyright do not pick up on it.

Add `Typing` to pyproject.toml and create `py.typed` in the module directory.

https://typing.readthedocs.io/en/latest/spec/distributing.html#packaging-typed-libraries