### PR TITLE
Allow connecting to chromecast over IPv6

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -11,6 +11,7 @@ from threading import Event
 import threading
 from typing import TYPE_CHECKING, Literal, cast, overload
 from uuid import UUID
+import socket
 
 import zeroconf
 
@@ -336,6 +337,7 @@ class Chromecast(CastStatusListener):
             retry_wait=retry_wait,
             services=cast_info.services,
             zconf=zconf,
+            ip_family=socket.AF_INET6 if ':' in cast_info.host else socket.AF_INET,
         )
 
         receiver_controller = self.socket_client.receiver_controller

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -11,7 +11,6 @@ from threading import Event
 import threading
 from typing import TYPE_CHECKING, Literal, cast, overload
 from uuid import UUID
-import socket
 
 import zeroconf
 
@@ -337,7 +336,6 @@ class Chromecast(CastStatusListener):
             retry_wait=retry_wait,
             services=cast_info.services,
             zconf=zconf,
-            ip_family=socket.AF_INET6 if ':' in cast_info.host else socket.AF_INET,
         )
 
         receiver_controller = self.socket_client.receiver_controller

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -350,7 +350,9 @@ class SocketClient(threading.Thread, CastStatusListener):
                         self.host,
                         self.port,
                     )
-                    self.socket = socket.create_connection((self.host, self.port), self.timeout)
+                    self.socket = socket.create_connection(
+                        (self.host, self.port), self.timeout
+                    )
                     configure_socket(self.socket)
                     self.remote_selector_key = self.selector.register(
                         self.socket, selectors.EVENT_READ

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -173,7 +173,6 @@ class SocketClient(threading.Thread, CastStatusListener):
         retry_wait: float | None,
         services: set[HostServiceInfo | MDNSServiceInfo],
         zconf: zeroconf.Zeroconf | None,
-        ip_family: socket.AddressFamily = socket.AF_INET,
     ) -> None:
         super().__init__()
 
@@ -193,7 +192,6 @@ class SocketClient(threading.Thread, CastStatusListener):
 
         self.host = "unknown"
         self.port = 8009
-        self.ip_family = ip_family
 
         self.source_id = "sender-0"
         self.stop = threading.Event()
@@ -293,11 +291,6 @@ class SocketClient(threading.Thread, CastStatusListener):
                         self.socket = None
                         self.remote_selector_key = None
 
-                    self.socket = new_socket(self.ip_family)
-                    self.remote_selector_key = self.selector.register(
-                        self.socket, selectors.EVENT_READ
-                    )
-                    self.socket.settimeout(self.timeout)
                     self._report_connection_status(
                         ConnectionStatus(
                             CONNECTION_STATUS_CONNECTING,
@@ -357,7 +350,11 @@ class SocketClient(threading.Thread, CastStatusListener):
                         self.host,
                         self.port,
                     )
-                    self.socket.connect((self.host, self.port))
+                    self.socket = socket.create_connection((self.host, self.port), self.timeout)
+                    configure_socket(self.socket)
+                    self.remote_selector_key = self.selector.register(
+                        self.socket, selectors.EVENT_READ
+                    )
                     context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
                     context.check_hostname = False
                     context.verify_mode = ssl.CERT_NONE
@@ -1087,15 +1084,14 @@ class ConnectionController(BaseController):
         return False
 
 
-def new_socket(family: socket.AddressFamily) -> socket.socket:
+def configure_socket(_socket: socket.socket) -> None:
     """
-    Create a new socket with OS-specific parameters
+    Configure a socket with OS-specific parameters
 
     Try to set SO_REUSEPORT for BSD-flavored systems if it's an option.
     Catches errors if not.
     """
-    new_sock = socket.socket(family, socket.SOCK_STREAM)
-    new_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    _socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
     try:
         # noinspection PyUnresolvedReferences
@@ -1104,10 +1100,8 @@ def new_socket(family: socket.AddressFamily) -> socket.socket:
         pass
     else:
         try:
-            new_sock.setsockopt(socket.SOL_SOCKET, reuseport, 1)
+            _socket.setsockopt(socket.SOL_SOCKET, reuseport, 1)
         except (OSError, socket.error) as err:
             # OSError on python 3, socket.error on python 2
             if err.errno != errno.ENOPROTOOPT:
                 raise
-
-    return new_sock

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -1086,14 +1086,14 @@ class ConnectionController(BaseController):
         return False
 
 
-def configure_socket(_socket: socket.socket) -> None:
+def configure_socket(socket_: socket.socket) -> None:
     """
     Configure a socket with OS-specific parameters
 
     Try to set SO_REUSEPORT for BSD-flavored systems if it's an option.
     Catches errors if not.
     """
-    _socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    socket_.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
     try:
         # noinspection PyUnresolvedReferences
@@ -1102,7 +1102,7 @@ def configure_socket(_socket: socket.socket) -> None:
         pass
     else:
         try:
-            _socket.setsockopt(socket.SOL_SOCKET, reuseport, 1)
+            socket_.setsockopt(socket.SOL_SOCKET, reuseport, 1)
         except (OSError, socket.error) as err:
             # OSError on python 3, socket.error on python 2
             if err.errno != errno.ENOPROTOOPT:


### PR DESCRIPTION
Currently, we can only connect to the chromecasts over IPv4 because `socket.AF_INET` is hardcoded for the socket.
This PR adds an automatic detection to choose from AF_INET6 or AF_INET, depending if the address contains colons or not