### PR TITLE
Prevent tight loop if Plex app failed to launch

### DIFF
--- a/pychromecast/controllers/plex.py
+++ b/pychromecast/controllers/plex.py
@@ -488,7 +488,9 @@ class PlexController(BaseController):
 
         def app_launched_callback(msg_sent: bool, _response: dict | None) -> None:
             if not msg_sent:
-                raise RequestFailed("PlexController.play_media")
+                self.logger.warning("PlexController.play_media: unable to launch app, device unavailable?")
+                self.play_media_event.set()
+                return
             try:
                 self._send_start_play(media, **kwargs)
             finally:


### PR DESCRIPTION
I've been tracking this one down for a while in Home Assistant.

Occasionally, when playing Plex media on a Google Home Mini, Home Assistant would get into a very tight loop (see https://github.com/home-assistant/core/issues/161641) if there was a failure launching the Plex app on the device.  This patch fixes that behavior by logging that it has happened, setting the event, and returning instead of raising an exception.

Prior to this patch, once this exception happened, Home Assistant would get into a tight loop and continuously log errors until all disk space was consumed.

I'm not super familiar with how pychromecast works, but understood enough to make it not fail.  :-)

Please review and apply if appropriate.