### PR TITLE
feat: IPv6-only support

### DIFF
--- a/pychromecast/const.py
+++ b/pychromecast/const.py
@@ -2,6 +2,11 @@
 Chromecast constants
 """
 
+from typing import TypeAlias
+
+# Type definitions / aliases
+HostnameType: TypeAlias = str
+
 # Regular chromecast, supports video/audio
 CAST_TYPE_CHROMECAST = "cast"
 # Cast Audio device, supports only audio

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import zeroconf
 
-from .const import CAST_TYPE_AUDIO, CAST_TYPE_CHROMECAST, CAST_TYPE_GROUP
+from .const import HostnameType, CAST_TYPE_AUDIO, CAST_TYPE_CHROMECAST, CAST_TYPE_GROUP
 from .error import ZeroConfInstanceRequired
 from .models import ZEROCONF_ERRORS, CastInfo, HostServiceInfo, MDNSServiceInfo
 
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_host_from_service(
     service: HostServiceInfo | MDNSServiceInfo, zconf: zeroconf.Zeroconf | None
-) -> tuple[str | None, int | None, zeroconf.ServiceInfo | None]:
+) -> tuple[HostnameType | None, int | None, zeroconf.ServiceInfo | None]:
     """Resolve host and port from service."""
     service_info = None
 
@@ -67,7 +67,10 @@ def _get_host_from_zc_service_info(
     port = None
     if service_info and service_info.port:
         if len(service_info.addresses) > 0:
-            host = socket.inet_ntoa(service_info.addresses[0])
+            if len(service_info.addresses[0]) == 8:
+                host = socket.inet_ntoa(service_info.addresses[0])
+            elif len(service_info.addresses[0]) == 16:
+                host = socket.inet_ntop(socket.AF_INET6, service_info.addresses[0])
         elif service_info.server is not None:
             host = service_info.server.lower()
         if host is not None:
@@ -148,7 +151,7 @@ def get_cast_type(
         cast_type = CAST_TYPE_GROUP
         manufacturer = "Google Inc."
     else:
-        host: str | None = "<unknown>"
+        host: HostnameType | None = "<unknown>"
         try:
             display_supported = True
             host, status = _get_status(
@@ -197,7 +200,7 @@ def get_cast_type(
 
 
 def get_device_info(  # pylint: disable=too-many-locals
-    host: str,
+    host: HostnameType,
     services: set[HostServiceInfo | MDNSServiceInfo] | None = None,
     zconf: zeroconf.Zeroconf | None = None,
     timeout: float = 30,
@@ -271,7 +274,7 @@ def get_device_info(  # pylint: disable=too-many-locals
         return None
 
 
-def _get_group_info(host: str, group: Any) -> MultizoneInfo:
+def _get_group_info(host: HostnameType, group: Any) -> MultizoneInfo:
     """Parse group JSON data and return a MultizoneInfo instance."""
     name = group.get("name", "Unknown group name")
     udn = group.get("uuid", None)
@@ -294,7 +297,7 @@ def _get_group_info(host: str, group: Any) -> MultizoneInfo:
 
 
 def get_multizone_status(
-    host: str,
+    host: HostnameType,
     services: set[HostServiceInfo | MDNSServiceInfo] | None = None,
     zconf: zeroconf.Zeroconf | None = None,
     timeout: float = 30,
@@ -339,7 +342,7 @@ class MultizoneInfo:
 
     friendly_name: str
     uuid: UUID | None
-    host: str | None
+    host: HostnameType | None
     port: int | None
 
 

--- a/pychromecast/models.py
+++ b/pychromecast/models.py
@@ -10,6 +10,8 @@ from uuid import UUID
 
 import zeroconf
 
+from .const import HostnameType
+
 # pylint: disable=invalid-name
 ZEROCONF_ERRORS: tuple[type[Exception], ...] = (IOError, asyncio.TimeoutError)
 if hasattr(zeroconf, "EventLoopBlocked"):
@@ -25,7 +27,7 @@ class CastInfo:
     uuid: UUID
     model_name: str | None
     friendly_name: str | None
-    host: str
+    host: HostnameType
     port: int
     cast_type: str | None
     manufacturer: str | None
@@ -35,7 +37,7 @@ class CastInfo:
 class HostServiceInfo:
     """Service info container."""
 
-    host: str
+    host: HostnameType
     port: int
 
 

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -21,11 +21,18 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass
 from struct import pack, unpack
+from typing import Any
 
 import zeroconf
 
 from .config import APP_AUDIBLE
-from .const import MESSAGE_TYPE, PLATFORM_DESTINATION_ID, REQUEST_ID, SESSION_ID
+from .const import (
+    HostnameType,
+    MESSAGE_TYPE,
+    PLATFORM_DESTINATION_ID,
+    REQUEST_ID,
+    SESSION_ID,
+)
 from .controllers import BaseController, CallbackType
 from .controllers.heartbeat import NS_HEARTBEAT, HeartbeatController
 from .controllers.media import MediaController
@@ -113,8 +120,35 @@ def _message_to_string(
 class NetworkAddress:
     """Network address container."""
 
-    address: str
-    port: int | None
+    host: HostnameType
+    port: int
+
+    def resolve(self) -> tuple[socket.AddressFamily, tuple[Any, ...]]:
+        """Resolve given hostname to an IP family (IPv4 or IPv6; 4 preferred),
+        and address to connect to."""
+        hostname: HostnameType = self.host
+        if ("[", "]") == (hostname[:1], hostname[-1:]) and ":" in hostname:
+            # IPv6 hostname annotation
+            hostname = hostname[1:-1]
+
+        family: socket.AddressFamily = socket.AF_INET
+        socket_address: tuple[Any, ...] = ()
+        try:
+            # Prefer IPv4
+            socket_address = socket.getaddrinfo(
+                hostname, self.port, socket.AF_INET, socket.SO_TYPE, socket.IPPROTO_TCP
+            )[-1]
+        except socket.gaierror:
+            # Fall-back to IPv6
+            socket_address = socket.getaddrinfo(
+                hostname, self.port, socket.AF_INET6, socket.SO_TYPE, socket.IPPROTO_TCP
+            )[-1]
+            family = socket.AF_INET6
+
+        return family, socket_address
+
+    def __str__(self) -> str:
+        return f"{self.host}:{self.port}"
 
 
 @dataclass(frozen=True)
@@ -190,8 +224,7 @@ class SocketClient(threading.Thread, CastStatusListener):
         self.services = services
         self.zconf = zconf
 
-        self.host = "unknown"
-        self.port = 8009
+        self.address = NetworkAddress("unknown", 8009)
 
         self.source_id = "sender-0"
         self.stop = threading.Event()
@@ -228,6 +261,16 @@ class SocketClient(threading.Thread, CastStatusListener):
         self.register_handler(self.media_controller)
 
         self.receiver_controller.register_status_listener(self)
+
+    @property
+    def host(self) -> HostnameType:
+        """Client hostname."""
+        return self.address.host
+
+    @property
+    def port(self) -> int:
+        """Client port."""
+        return self.address.port
 
     def initialize_connection(  # pylint:disable=too-many-statements, too-many-branches
         self,
@@ -284,28 +327,9 @@ class SocketClient(threading.Thread, CastStatusListener):
                 if now < retry["next_retry"]:
                     continue
                 try:
-                    if self.socket is not None:
-                        # If we retry connecting, we need to clean up the socket again
-                        self.selector.unregister(self.socket)
-                        self.socket.close()
-                        self.socket = None
-                        self.remote_selector_key = None
-
-                    self.socket = new_socket()
-                    self.remote_selector_key = self.selector.register(
-                        self.socket, selectors.EVENT_READ
-                    )
-                    self.socket.settimeout(self.timeout)
-                    self._report_connection_status(
-                        ConnectionStatus(
-                            CONNECTION_STATUS_CONNECTING,
-                            NetworkAddress(self.host, self.port),
-                            None,
-                        )
-                    )
                     # Resolve the service name.
-                    host = None
-                    port = None
+                    host: HostnameType | None = None
+                    port: int | None = None
                     host, port, service_info = get_host_from_service(
                         service, self.zconf
                     )
@@ -317,22 +341,20 @@ class SocketClient(threading.Thread, CastStatusListener):
                             except (AttributeError, KeyError, UnicodeError):
                                 pass
                         self.logger.debug(
-                            "[%s(%s):%s] Resolved service %s to %s:%s",
+                            "[%s(%s):%s] Resolved service %s to %s",
                             self.fn or "",
-                            self.host,
-                            self.port,
+                            self.address.host,
+                            self.address.port,
                             service,
-                            host,
-                            port,
+                            self.address,
                         )
-                        self.host = host
-                        self.port = port
+                        self.address = NetworkAddress(host, port)
                     else:
                         self.logger.debug(
                             "[%s(%s):%s] Failed to resolve service %s",
                             self.fn or "",
-                            self.host,
-                            self.port,
+                            self.address.host,
+                            self.address.port,
                             service,
                         )
                         self._report_connection_status(
@@ -347,15 +369,55 @@ class SocketClient(threading.Thread, CastStatusListener):
                         # try next service
                         continue
 
-                    self.logger.debug(
-                        "[%s(%s):%s] Connecting to %s:%s",
-                        self.fn or "",
-                        self.host,
-                        self.port,
-                        self.host,
-                        self.port,
+                    if self.socket is not None:
+                        # If we retry connecting, we need to clean up the socket again
+                        self.selector.unregister(self.socket)
+                        self.socket.close()
+                        self.socket = None
+                        self.remote_selector_key = None
+
+                    try:
+                        family, socket_address = self.address.resolve()
+                    except socket.gaierror:
+                        self.logger.debug(
+                            "[%s(%s):%s] Failed to resolve service %s to IP",
+                            self.fn or "",
+                            self.address.host,
+                            self.address.port,
+                            service,
+                        )
+                        self._report_connection_status(
+                            ConnectionStatus(
+                                CONNECTION_STATUS_FAILED_RESOLVE,
+                                None,
+                                service,
+                            )
+                        )
+                        mdns_backoff(service, retry)
+                        # If zeroconf fails to receive the necessary data,
+                        # try next service
+                        continue
+
+                    self.socket = new_socket(family)
+                    self.remote_selector_key = self.selector.register(
+                        self.socket, selectors.EVENT_READ
                     )
-                    self.socket.connect((self.host, self.port))
+                    self.socket.settimeout(self.timeout)
+                    self._report_connection_status(
+                        ConnectionStatus(
+                            CONNECTION_STATUS_CONNECTING,
+                            self.address,
+                            None,
+                        )
+                    )
+                    self.logger.debug(
+                        "[%s(%s):%s] Connecting to %s",
+                        self.fn or "",
+                        self.address.host,
+                        self.address.port,
+                        self.address,
+                    )
+                    self.socket.connect(socket_address)
                     context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
                     context.check_hostname = False
                     context.verify_mode = ssl.CERT_NONE
@@ -365,7 +427,7 @@ class SocketClient(threading.Thread, CastStatusListener):
                     self._report_connection_status(
                         ConnectionStatus(
                             CONNECTION_STATUS_CONNECTED,
-                            NetworkAddress(self.host, self.port),
+                            self.address,
                             None,
                         )
                     )
@@ -378,15 +440,15 @@ class SocketClient(threading.Thread, CastStatusListener):
                         self.logger.debug(
                             "[%s(%s):%s] Connected!",
                             self.fn or "",
-                            self.host,
-                            self.port,
+                            self.address.host,
+                            self.address.port,
                         )
                     else:
                         self.logger.info(
                             "[%s(%s):%s] Connection reestablished!",
                             self.fn or "",
-                            self.host,
-                            self.port,
+                            self.address.host,
+                            self.address.port,
                         )
                     return
 
@@ -399,8 +461,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                         self.logger.error(
                             "[%s(%s):%s] Failed to connect: %s. aborting due to stop signal.",
                             self.fn or "",
-                            self.host,
-                            self.port,
+                            self.address.host,
+                            self.address.port,
                             err,
                         )
                         raise ChromecastConnectionError("Failed to connect") from err
@@ -408,15 +470,15 @@ class SocketClient(threading.Thread, CastStatusListener):
                     self._report_connection_status(
                         ConnectionStatus(
                             CONNECTION_STATUS_FAILED,
-                            NetworkAddress(self.host, self.port),
+                            self.address,
                             None,
                         )
                     )
                     retry_log_fun(
                         "[%s(%s):%s] Failed to connect to service %s, retrying in %.1fs",
                         self.fn or "",
-                        self.host,
-                        self.port,
+                        self.address.host,
+                        self.address.port,
                         service,
                         retry["delay"],
                     )
@@ -428,8 +490,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.logger.debug(
                     "[%s(%s):%s] Not connected, sleeping for %.1fs. Services: %s",
                     self.fn or "",
-                    self.host,
-                    self.port,
+                    self.address.host,
+                    self.address.port,
                     self.retry_wait,
                     self.services,
                 )
@@ -442,8 +504,8 @@ class SocketClient(threading.Thread, CastStatusListener):
         self.logger.error(
             "[%s(%s):%s] Failed to connect. No retries.",
             self.fn or "",
-            self.host,
-            self.port,
+            self.address.host,
+            self.address.port,
         )
         raise ChromecastConnectionError("Failed to connect")
 
@@ -534,7 +596,7 @@ class SocketClient(threading.Thread, CastStatusListener):
             self._report_connection_status(
                 ConnectionStatus(
                     CONNECTION_STATUS_DISCONNECTED,
-                    NetworkAddress(self.host, self.port),
+                    self.address,
                     None,
                 )
             )
@@ -551,8 +613,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.logger.exception(
                     "[%s(%s):%s] Unhandled exception in worker thread, attempting reconnect",
                     self.fn or "",
-                    self.host,
-                    self.port,
+                    self.address.host,
+                    self.address.port,
                 )
 
         self.logger.debug("Thread done...")
@@ -583,8 +645,8 @@ class SocketClient(threading.Thread, CastStatusListener):
             self.logger.error(
                 "[%s(%s):%s] Error in select call: %s",
                 self.fn or "",
-                self.host,
-                self.port,
+                self.address.host,
+                self.address.port,
                 exc,
             )
             self._force_recon = True
@@ -601,15 +663,15 @@ class SocketClient(threading.Thread, CastStatusListener):
                     self.logger.info(
                         "[%s(%s):%s] Stopped while reading message, disconnecting.",
                         self.fn or "",
-                        self.host,
-                        self.port,
+                        self.address.host,
+                        self.address.port,
                     )
                 else:
                     self.logger.error(
                         "[%s(%s):%s] Interruption caught without being stopped: %s",
                         self.fn or "",
-                        self.host,
-                        self.port,
+                        self.address.host,
+                        self.address.port,
                         exc,
                     )
                 return 1
@@ -623,8 +685,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.logger.debug(
                     "[%s(%s):%s] %s",
                     self.fn or "",
-                    self.host,
-                    self.port,
+                    self.address.host,
+                    self.address.port,
                     exc,
                 )
             except socket.error as exc:
@@ -632,8 +694,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.logger.error(
                     "[%s(%s):%s] Error reading from socket: %s",
                     self.fn or "",
-                    self.host,
-                    self.port,
+                    self.address.host,
+                    self.address.port,
                     exc,
                 )
 
@@ -671,8 +733,8 @@ class SocketClient(threading.Thread, CastStatusListener):
             self.logger.debug(
                 "[%s(%s):%s] Forced reconnection",
                 self.fn or "",
-                self.host,
-                self.port,
+                self.address.host,
+                self.address.port,
             )
             reset = True
 
@@ -680,8 +742,8 @@ class SocketClient(threading.Thread, CastStatusListener):
             self.logger.info(
                 "[%s(%s):%s] Heartbeat timeout, resetting connection",
                 self.fn or "",
-                self.host,
-                self.port,
+                self.address.host,
+                self.address.port,
             )
             reset = True
 
@@ -690,9 +752,7 @@ class SocketClient(threading.Thread, CastStatusListener):
             for channel in self._open_channels:
                 self.disconnect_channel(channel)
             self._report_connection_status(
-                ConnectionStatus(
-                    CONNECTION_STATUS_LOST, NetworkAddress(self.host, self.port), None
-                )
+                ConnectionStatus(CONNECTION_STATUS_LOST, self.address, None)
             )
             try:
                 self.initialize_connection()
@@ -713,8 +773,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.logger.debug(
                     "[%s(%s):%s] Received: %s",
                     self.fn or "",
-                    self.host,
-                    self.port,
+                    self.address.host,
+                    self.address.port,
                     _message_to_string(message, data),
                 )
 
@@ -728,8 +788,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                             self.logger.debug(
                                 "[%s(%s):%s] Message unhandled: %s",
                                 self.fn or "",
-                                self.host,
-                                self.port,
+                                self.address.host,
+                                self.address.port,
                                 _message_to_string(message, data),
                             )
                 except Exception:  # pylint: disable=broad-except
@@ -739,8 +799,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                             "controller %s: %s"
                         ),
                         self.fn or "",
-                        self.host,
-                        self.port,
+                        self.address.host,
+                        self.address.port,
                         type(handler).__name__,
                         _message_to_string(message, data),
                     )
@@ -749,8 +809,8 @@ class SocketClient(threading.Thread, CastStatusListener):
             self.logger.debug(
                 "[%s(%s):%s] Received unknown namespace: %s",
                 self.fn or "",
-                self.host,
-                self.port,
+                self.address.host,
+                self.address.port,
                 _message_to_string(message, data),
             )
 
@@ -774,12 +834,15 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.socket.close()
             except Exception:  # pylint: disable=broad-except
                 self.logger.exception(
-                    "[%s(%s):%s] _cleanup", self.fn or "", self.host, self.port
+                    "[%s(%s):%s] _cleanup",
+                    self.fn or "",
+                    self.address.host,
+                    self.address.port,
                 )
         self._report_connection_status(
             ConnectionStatus(
                 CONNECTION_STATUS_DISCONNECTED,
-                NetworkAddress(self.host, self.port),
+                self.address,
                 None,
             )
         )
@@ -797,8 +860,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.logger.debug(
                     "[%s(%s):%s] connection listener: %x (%s) %s",
                     self.fn or "",
-                    self.host,
-                    self.port,
+                    self.address.host,
+                    self.address.port,
                     id(listener),
                     type(listener).__name__,
                     status,
@@ -808,8 +871,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.logger.exception(
                     "[%s(%s):%s] Exception thrown when calling connection listener",
                     self.fn or "",
-                    self.host,
-                    self.port,
+                    self.address.host,
+                    self.address.port,
                 )
 
     def _read_bytes_from_socket(self, msglen: int) -> bytes:
@@ -832,8 +895,8 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.logger.debug(
                     "[%s(%s):%s] timeout in : _read_bytes_from_socket",
                     self.fn or "",
-                    self.host,
-                    self.port,
+                    self.address.host,
+                    self.address.port,
                 )
                 continue
         return b"".join(chunks)
@@ -900,8 +963,8 @@ class SocketClient(threading.Thread, CastStatusListener):
             self.logger.debug(
                 "[%s(%s):%s] Sending: %s",
                 self.fn or "",
-                self.host,
-                self.port,
+                self.address.host,
+                self.address.port,
                 _message_to_string(msg, data),
             )
 
@@ -929,14 +992,14 @@ class SocketClient(threading.Thread, CastStatusListener):
                 self.logger.warning(
                     "[%s(%s):%s] Error writing to socket: %s",
                     self.fn or "",
-                    self.host,
-                    self.port,
+                    self.address.host,
+                    self.address.port,
                     exc,
                 )
         else:
             if callback_function:
                 callback_function(False, None)
-            raise NotConnected(f"Chromecast {self.host}:{self.port} is connecting...")
+            raise NotConnected(f"Chromecast {self.address} is connecting...")
 
     def send_platform_message(
         self,
@@ -1036,7 +1099,10 @@ class SocketClient(threading.Thread, CastStatusListener):
                 pass
             except Exception:  # pylint: disable=broad-except
                 self.logger.exception(
-                    "[%s(%s):%s] Exception", self.fn or "", self.host, self.port
+                    "[%s(%s):%s] Exception",
+                    self.fn or "",
+                    self.address.host,
+                    self.address.port,
                 )
 
             self._open_channels.remove(destination_id)
@@ -1085,14 +1151,14 @@ class ConnectionController(BaseController):
         return False
 
 
-def new_socket() -> socket.socket:
+def new_socket(family: socket.AddressFamily) -> socket.socket:
     """
     Create a new socket with OS-specific parameters
 
     Try to set SO_REUSEPORT for BSD-flavored systems if it's an option.
     Catches errors if not.
     """
-    new_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    new_sock = socket.socket(family, socket.SOCK_STREAM)
     new_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
     try:

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -123,26 +123,30 @@ class NetworkAddress:
     host: HostnameType
     port: int
 
-    def resolve(self) -> tuple[socket.AddressFamily, tuple[Any, ...]]:
-        """Resolve given hostname to an IP family (IPv4 or IPv6; 4 preferred),
-        and address to connect to."""
+    def get_socket_address(self):
+        # Clean up hostname annotation. Older Linux kernels don't like getaddrinfo with the IPv6 square bracket format.
         hostname: HostnameType = self.host
         if ("[", "]") == (hostname[:1], hostname[-1:]) and ":" in hostname:
             # IPv6 hostname annotation
             hostname = hostname[1:-1]
+        return (hostname, self.port)
 
+    def resolve(self) -> tuple[socket.AddressFamily, tuple[HostnameType, int]]:
+        """Resolve given hostname to an IP family (IPv4 or IPv6; 4 preferred),
+        and address to connect to."""
         family: socket.AddressFamily = socket.AF_INET
-        socket_address: tuple[Any, ...] = ()
+        socket_address = self.get_socket_address()
+
         try:
             # Prefer IPv4
-            socket_address = socket.getaddrinfo(
-                hostname, self.port, socket.AF_INET, socket.SO_TYPE, socket.IPPROTO_TCP
-            )[-1]
+            socket.getaddrinfo(
+                *socket_address,
+                family=socket.AF_INET,
+                type=socket.SOCK_STREAM,
+                proto=socket.IPPROTO_TCP,
+            )
         except socket.gaierror:
-            # Fall-back to IPv6
-            socket_address = socket.getaddrinfo(
-                hostname, self.port, socket.AF_INET6, socket.SO_TYPE, socket.IPPROTO_TCP
-            )[-1]
+            # Fall-back to IPv6.
             family = socket.AF_INET6
 
         return family, socket_address
@@ -378,6 +382,15 @@ class SocketClient(threading.Thread, CastStatusListener):
 
                     try:
                         family, socket_address = self.address.resolve()
+                        self.logger.debug(
+                            "[%s(%s):%s] Resolved service %s to IPv%d, %s",
+                            self.fn or "",
+                            self.address.host,
+                            self.address.port,
+                            service,
+                            4 if family == socket.AF_INET else 6,
+                            socket_address[0],
+                        )
                     except socket.gaierror:
                         self.logger.debug(
                             "[%s(%s):%s] Failed to resolve service %s to IP",


### PR DESCRIPTION
For devices which only have IPv6 addresses, this change allows creation of IPv6 sockets or IPv4 sockets, depending on what is available.

It does not allow for Happy Eyeballs implementation on dual-stack, which would require a much larger refactor.

`[abcd:1234::6789]` notation is retained for HTTP connections (required to distinguish the address from the port), but stripped out for the TCP socket connection, since some implementations of `getaddrinfo` do not support this notation as input, only the raw IPv6 address.