### PR TITLE
clear callbacks on exception to prevent infinite loop.

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -548,6 +548,7 @@ class SocketClient(threading.Thread, CastStatusListener):
                     break
             except Exception:  # pylint: disable=broad-except
                 self._force_recon = True
+                self._request_callbacks = {}
                 self.logger.exception(
                     "[%s(%s):%s] Unhandled exception in worker thread, attempting reconnect",
                     self.fn or "",


### PR DESCRIPTION
When the Plex controller throws an exception (RequestFailed("PlexController.play_media")), there are still entries in the socket client's _request_callbacks dictionary.

When the reconnection attempt happens, it tries to handle the pending callbacks. In the case of Plex, though, the callback function sees that the previous message failed to send and it throws another exception.  This repeats indefinitely, until my disk fills up completely with logs.

I attempted to handle this previously in pull request #1164 but that masked the exception. This attempt still logs the exception and successfully reconnects.

I'm not going to say this is perfect, as there was probably a reason for those callbacks to be processed, especially with the comment "# Make sure nobody is blocking."

Regardless, I am submitting this for review since I do feel that I've figured out why / how the code gets into a tight loop and I'm hoping that you can provide some context on what the socket client is trying to do with the callbacks before a new connection is initialized.