### PR TITLE
Swallow and log unhandled exceptions when callbacks are called

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -243,7 +243,15 @@ class SocketClient(threading.Thread, CastStatusListener):
 
         # Make sure nobody is blocking.
         for callback_function in self._request_callbacks.values():
-            callback_function(False, None)
+            try:
+                callback_function(False, None)
+            except Exception:  # pylint: disable=broad-except
+                self.logger.exception(
+                    "[%s(%s):%s] Unhandled exception in callback function",
+                    self.fn or "",
+                    self.host,
+                    self.port,
+                )
 
         self.app_namespaces = []
         self.destination_id = None


### PR DESCRIPTION
This is my third attempt at this, with prior attempts being #1164 and #1208, discussed in https://github.com/home-assistant/core/issues/161641

This change catches the exception at the socket client level and should function with any handler that happens to throw an exception which is unhandled in a callback.

I've watched my logs and can confirm that the exception is thrown from the Plex handler as it tries to issue the callbacks on reconnect, caught and logged in the socket client, and the connection is successfully re-established.
