### PR TITLE
Handle expected Cast disconnects

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -67,6 +67,12 @@ SELECT_TIMEOUT = 5.0
 TIMEOUT_TIME = 30.0
 RETRY_TIME = 5.0
 
+# Errors reported when a Cast device closes or resets its connection. Devices
+# commonly do this as part of their regular restart cycle.
+EXPECTED_DISCONNECT_ERRNOS = frozenset(
+    (errno.ECONNABORTED, errno.ECONNRESET, errno.ENOTCONN, errno.EPIPE)
+)
+
 
 class InterruptLoop(Exception):
     """The chromecast has been manually stopped."""
@@ -622,10 +628,17 @@ class SocketClient(threading.Thread, CastStatusListener):
                     )
                 return 1
             except ssl.SSLError as exc:
-                if exc.errno == ssl.SSL_ERROR_EOF:
-                    if self.stop.is_set():
-                        return 1
-                raise
+                if exc.errno != ssl.SSL_ERROR_EOF:
+                    raise
+                if self.stop.is_set():
+                    return 1
+                self._force_recon = True
+                self.logger.debug(
+                    "[%s(%s):%s] TLS connection was closed by remote",
+                    self.fn or "",
+                    self.host,
+                    self.port,
+                )
             except ChromecastConnectionClosed as exc:
                 self._force_recon = True
                 self.logger.debug(
@@ -637,7 +650,12 @@ class SocketClient(threading.Thread, CastStatusListener):
                 )
             except socket.error as exc:
                 self._force_recon = True
-                self.logger.error(
+                log = (
+                    self.logger.debug
+                    if exc.errno in EXPECTED_DISCONNECT_ERRNOS
+                    else self.logger.error
+                )
+                log(
                     "[%s(%s):%s] Error reading from socket: %s",
                     self.fn or "",
                     self.host,


### PR DESCRIPTION
# Draft PR: Treat expected Cast disconnects as reconnect events

## Summary

Handle TLS EOFs and common TCP disconnect errors caused by Cast device restarts
as expected reconnect events. The socket client still sets `_force_recon`, but
logs these conditions at DEBUG rather than ERROR.

## Why

Google Cast devices commonly restart and close their existing TLS connection.
`ChromecastConnectionClosed` is already handled as an expected disconnect, but
TLS EOFs and errors such as `ECONNRESET` currently reach the ERROR log path.
This causes misleading errors for normal device restarts.

Unexpected socket errors keep their existing ERROR log level.

## Validation

- `python3 -m compileall -q pychromecast`
- `ruff format pychromecast --check --diff`
- `ruff check pychromecast`
- `mypy pychromecast`

All checks passed locally.

## Reviewer checklist

- Confirm that `ECONNABORTED`, `ECONNRESET`, `ENOTCONN`, and `EPIPE` are the
  intended set of expected peer-disconnect errors.
- Confirm that a TLS EOF should follow the same reconnect path as a clean EOF.
- Confirm the desired log level for these events is DEBUG.
